### PR TITLE
LEF-68 - Refactor storage location to support multiple impls

### DIFF
--- a/lib/longleaf/events/register_event.rb
+++ b/lib/longleaf/events/register_event.rb
@@ -77,7 +77,7 @@ module Longleaf
       md_rec = @file_rec.metadata_record
 
       old_md = MetadataDeserializer.deserialize(file_path: @file_rec.metadata_path,
-              digest_algs: @file_rec.storage_location.metadata_digests)
+              digest_algs: @file_rec.storage_location.metadata_location.digests)
       # Copy custom properties
       old_md.properties.each { |name, value| md_rec.properties[name] = value }
       # Copy stale-replicas flag per service

--- a/lib/longleaf/models/app_fields.rb
+++ b/lib/longleaf/models/app_fields.rb
@@ -7,7 +7,11 @@ module Longleaf
     SYSTEM = 'system'
 
     LOCATION_PATH = 'path'
-    METADATA_PATH = 'metadata_path'
-    METADATA_DIGESTS = 'metadata_digests'
+    METADATA_CONFIG = 'metadata'
+    METADATA_DIGESTS = 'digests'
+
+    STORAGE_TYPE = 'type'
+
+    FILESYSTEM_STORAGE_TYPE = 'filesystem'
   end
 end

--- a/lib/longleaf/models/filesystem_metadata_location.rb
+++ b/lib/longleaf/models/filesystem_metadata_location.rb
@@ -1,0 +1,50 @@
+require 'longleaf/services/metadata_serializer'
+require 'longleaf/models/metadata_location'
+
+module Longleaf
+  # A filesystem based location in which metadata associated with registered files is stored.
+  class FilesystemMetadataLocation < MetadataLocation
+    AF ||= Longleaf::AppFields
+
+    def initialize(config)
+      super(config)
+    end
+
+    # Get the absolute path for the metadata file for the given file path located in this storage location.
+    # @param file_path [String] path of the file relative its storage location
+    # @return absolute path to the metadata
+    # @raise [ArgumentError] if the file_path is not provided.
+    def metadata_path_for(file_path)
+      raise ArgumentError.new("A file_path parameter is required") if file_path.nil?
+      raise ArgumentError.new("File path must be relative") if Pathname.new(file_path).absolute?
+
+      md_path = File.join(@path, file_path)
+      # If the file_path is to a file, then add metadata suffix.
+      if md_path.end_with?('/')
+        md_path
+      else
+        md_path + MetadataSerializer::metadata_suffix
+      end
+    end
+
+    # Get the metadata path relative to this location
+    # @param md_path [String] metadata file path
+    # @return the metadata path relative to this location
+    # @raise [ArgumentError] if the metadata path is not contained by this location
+    def relativize(md_path)
+      return md_path if Pathname.new(md_path).relative?
+
+      raise ArgumentError.new("Metadata path must be contained by this location") if !md_path.start_with?(@path)
+
+      md_path.sub(@path, "")
+    end
+
+
+    # Checks that the path defined in this metadata location are available
+    # @raise [StorageLocationUnavailableError] if the metadata location is not available
+    def available?
+      raise StorageLocationUnavailableError.new("Metadata path does not exist or is not a directory: #{@path}")\
+          unless Dir.exist?(@path)
+    end
+  end
+end

--- a/lib/longleaf/models/filesystem_storage_location.rb
+++ b/lib/longleaf/models/filesystem_storage_location.rb
@@ -1,0 +1,38 @@
+require 'longleaf/models/storage_location'
+
+module Longleaf
+  # A storage location in a local filesystem
+  class FilesystemStorageLocation < StorageLocation
+    # Get that absolute path to the file associated with the provided metadata path
+    # @param md_path [String] metadata file path
+    # @raise [ArgumentError] if the md_path is not in this storage location
+    # @return [String] the path for the file associated with this metadata
+    def get_path_from_metadata_path(md_path)
+      raise ArgumentError.new("A file_path parameter is required") if md_path.nil? || md_path.empty?
+
+      rel_path = @metadata_location.relative_file_path_for(md_path)
+
+      File.join(@path, rel_path)
+    end
+
+    # Checks that the path and metadata path defined in this location are available
+    # @raise [StorageLocationUnavailableError] if the storage location is not available
+    def available?
+      raise StorageLocationUnavailableError.new("Path does not exist or is not a directory: #{@path}")\
+          unless Dir.exist?(@path)
+      @metadata_location.available?
+    end
+
+    # Get the file path relative to this location
+    # @param file_path [String] file path
+    # @return the file path relative to this location
+    # @raise [ArgumentError] if the file path is not contained by this location
+    def relativize(file_path)
+      return file_path if Pathname.new(file_path).relative?
+
+      raise ArgumentError.new("Metadata path must be contained by this location") if !file_path.start_with?(@path)
+
+      file_path.sub(@path, "")
+    end
+  end
+end

--- a/lib/longleaf/models/metadata_location.rb
+++ b/lib/longleaf/models/metadata_location.rb
@@ -1,0 +1,47 @@
+require 'longleaf/models/app_fields'
+
+module Longleaf
+  # A location in which metadata associated with registered files is stored.
+  class MetadataLocation
+    AF ||= Longleaf::AppFields
+
+    attr_reader :path
+    attr_reader :digests
+
+    def initialize(config)
+      raise ArgumentError.new("Config parameter is required") unless config
+      @path = config[AF::LOCATION_PATH]
+      raise ArgumentError.new("Parameter path is required") unless @path
+      @path += '/' unless @path.end_with?('/')
+
+      digests = config[AF::METADATA_DIGESTS]
+      if digests.nil?
+        @digests = []
+      elsif digests.is_a?(String)
+        @digests = [digests.downcase]
+      else
+        @digests = digests.map(&:downcase)
+      end
+      DigestHelper::validate_algorithms(@digests)
+    end
+
+    # Transforms the given metadata path into a relative storage location path
+    # @param md_path [String] path of the metadata file or directory to compute file path for.
+    # @return
+    def relative_file_path_for(md_path)
+      rel_md_path = relativize(md_path)
+
+      if rel_md_path.end_with?(MetadataSerializer::metadata_suffix)
+        rel_md_path[0..-MetadataSerializer::metadata_suffix.length - 1]
+      else
+        rel_md_path
+      end
+    end
+
+    # @param [String] metadata path to check
+    # @return true if the metadata path is contained by the path for this location
+    def contains?(md_path)
+      md_path.start_with?(@path)
+    end
+  end
+end

--- a/lib/longleaf/models/storage_location.rb
+++ b/lib/longleaf/models/storage_location.rb
@@ -1,34 +1,25 @@
-require 'longleaf/services/metadata_serializer'
+require 'longleaf/models/app_fields'
 
 module Longleaf
   # Representation of a configured storage location
   class StorageLocation
+    AF ||= Longleaf::AppFields
+
     attr_reader :name
     attr_reader :path
-    attr_reader :metadata_path
-    attr_reader :metadata_digests
+    attr_reader :metadata_location
 
     # @param name [String] the name of this storage location
-    # @param path [String] absolute path where the storage location is located
-    # @param metadata_path [String] absolute path where the metadata for files in this location will be stored.
-    # @param metadata_digests list of digest algorithms to use for metadata file digests in this location.
-    def initialize(name:, path:, metadata_path:, metadata_digests: [])
-      raise ArgumentError.new("Parameters name, path and metadata_path are required") unless name && path && metadata_path
-
-      @path = path
-      @path += '/' unless @path.end_with?('/')
+    # @param config [Hash] hash containing the configuration options for this location
+    # @param md_loc [MetadataLocation] metadata location associated with this storage location
+    def initialize(name, config, md_loc)
+      raise ArgumentError.new("Config parameter is required") unless config
+      @path = config[AF::LOCATION_PATH]
       @name = name
-      @metadata_path = metadata_path
-      @metadata_path += '/' unless @metadata_path.end_with?('/')
+      raise ArgumentError.new("Parameters name, path and metadata location are required") unless @name && @path && md_loc
 
-      if metadata_digests.nil?
-        @metadata_digests = []
-      elsif metadata_digests.is_a?(String)
-        @metadata_digests = [metadata_digests.downcase]
-      else
-        @metadata_digests = metadata_digests.map(&:downcase)
-      end
-      DigestHelper::validate_algorithms(@metadata_digests)
+      @path += '/' unless @path.end_with?('/')
+      @metadata_location = md_loc
     end
 
     # Get the path for the metadata file for the given file path located in this storage location.
@@ -39,35 +30,15 @@ module Longleaf
       raise ArgumentError.new("Provided file path is not contained by storage location #{@name}: #{file_path}") \
           unless file_path.start_with?(@path)
 
-      md_path = file_path.sub(/^#{@path}/, @metadata_path)
-      # If the file_path is to a file, then add metadata suffix.
-      if md_path.end_with?('/')
-        md_path
-      else
-        md_path + MetadataSerializer::metadata_suffix
-      end
+      rel_file_path = relativize(file_path)
+
+      @metadata_location.metadata_path_for(rel_file_path)
     end
 
-    # Get the metadata path for the provided file path located in this storage location.
-    # @param md_path [String] metadata file path
-    # @raise [ArgumentError] if the md_path is not in this storage location
-    # @return [String] the path for the file associated with this metadata
-    def get_path_from_metadata_path(md_path)
-      raise ArgumentError.new("A file_path parameter is required") if md_path.nil? || md_path.empty?
-      raise ArgumentError.new("Provided metadata path is not contained by storage location #{@name}: #{md_path}") \
-          unless md_path&.start_with?(@metadata_path)
-
-      file_path = md_path.sub(/^#{@metadata_path}/, @path)
-      file_path.sub(/#{MetadataSerializer::metadata_suffix}$/, '')
-    end
-
-    # Checks that the path and metadata path defined in this location are available
-    # @raise [StorageLocationUnavailableError] if the storage location is not available
-    def available?
-      raise StorageLocationUnavailableError.new("Path does not exist or is not a directory: #{@path}")\
-          unless Dir.exist?(@path)
-      raise StorageLocationUnavailableError.new("Metadata path does not exist or is not a directory: #{@metadata_path}")\
-          unless Dir.exist?(@metadata_path)
+    # @param [String] path to check
+    # @return true if the file path is contained by the path for this location
+    def contains?(file_path)
+      file_path.start_with?(@path)
     end
   end
 end

--- a/lib/longleaf/services/application_config_deserializer.rb
+++ b/lib/longleaf/services/application_config_deserializer.rb
@@ -60,7 +60,15 @@ module Longleaf
       config[AF::LOCATIONS].each do |name, properties|
         properties[AF::LOCATION_PATH] = absolution(base_pathname, properties[AF::LOCATION_PATH])
 
-        properties[AF::METADATA_PATH] = absolution(base_pathname, properties[AF::METADATA_PATH])
+        # Resolve single field metadata location into expanded form
+        md_config = properties[AF::METADATA_CONFIG]
+        if md_config.nil?
+          next
+        end
+        if md_config.is_a?(String)
+          md_config = { AF::LOCATION => m_config }
+        end
+        md_config[AF::LOCATION_PATH] = absolution(base_pathname, md_config[AF::LOCATION_PATH])
       end
     end
 

--- a/lib/longleaf/services/metadata_persistence_manager.rb
+++ b/lib/longleaf/services/metadata_persistence_manager.rb
@@ -21,7 +21,7 @@ module Longleaf
 
       MetadataSerializer::write(metadata: file_rec.metadata_record,
           file_path: file_rec.metadata_path,
-          digest_algs: file_rec.storage_location.metadata_digests)
+          digest_algs: file_rec.storage_location.metadata_location.digests)
 
       index(file_rec)
     end
@@ -39,7 +39,7 @@ module Longleaf
     # @return [MetadataRecord] the metadata record for the file record
     def load(file_rec)
       md_rec = MetadataDeserializer.deserialize(file_path: file_rec.metadata_path,
-                  digest_algs: file_rec.storage_location.metadata_digests)
+                  digest_algs: file_rec.storage_location.metadata_location.digests)
       file_rec.metadata_record = md_rec
       md_rec
     end

--- a/lib/longleaf/specs/config_builder.rb
+++ b/lib/longleaf/specs/config_builder.rb
@@ -27,14 +27,21 @@ module Longleaf
     # @param path [String] value for the 'path' field
     # @param md_path [String] value for the 'metadata_path' field
     # @return this builder
-    def with_location(name:, path: '/file/path/', md_path: '/metadata/path/', md_digests: nil)
+    def with_location(name:, path: '/file/path/', s_type: nil, md_path: '/metadata/path/', md_type: nil, md_digests: nil)
       @config[AF::LOCATIONS] = Hash.new unless @config.key?(AF::LOCATIONS)
 
       location = {}
       @config[AF::LOCATIONS][name] = location
       location[AF::LOCATION_PATH] = path unless path.nil?
-      location[AF::METADATA_PATH] = md_path unless md_path.nil?
-      location[AF::METADATA_DIGESTS] = md_digests unless md_digests.nil?
+      location[AF::STORAGE_TYPE] = s_type unless s_type.nil?
+
+      if !md_path.nil?
+        md_loc = { AF::LOCATION_PATH => md_path }
+        location[AF::METADATA_CONFIG] = md_loc
+
+        md_loc[AF::METADATA_DIGESTS] = md_digests unless md_digests.nil?
+        md_loc[AF::STORAGE_TYPE] = md_type unless md_type.nil?
+      end
       self
     end
 

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -1,13 +1,39 @@
-require 'longleaf/models/storage_location'
+require 'longleaf/models/filesystem_storage_location'
+require 'longleaf/models/filesystem_metadata_location'
 require 'longleaf/services/storage_location_manager'
+require 'longleaf/models/app_fields'
 
 FactoryBot.define do
-  factory(:storage_location, class: Longleaf::StorageLocation) do
-    name { 's_loc' }
-    path { '/file/path/' }
-    metadata_path { '/metadata/path/' }
+  AF ||= Longleaf::AppFields
 
-    initialize_with { new(attributes) }
+  factory(:storage_location, class: Longleaf::FilesystemStorageLocation) do
+    transient {
+      path { '/file/path/' }
+      metadata_path { '/metadata/path/' }
+      metadata_config { { AF::LOCATION_PATH => metadata_path } }
+    }
+
+    name { 's_loc' }
+    config { {
+      AF::LOCATION_PATH => path
+    } }
+    md_loc { build(:metadata_location, config: metadata_config) }
+
+    initialize_with { new(name, config, md_loc) }
+  end
+
+  factory(:metadata_location, class: Longleaf::FilesystemMetadataLocation) do
+    transient {
+      path { '/metadata/path/' }
+      digests { nil }
+    }
+
+    config { {
+      AF::LOCATION_PATH => path,
+      AF::METADATA_DIGESTS => digests
+    } }
+
+    initialize_with { new(config) }
   end
 
   factory(:storage_location_manager, class: Longleaf::StorageLocationManager) do

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -51,7 +51,7 @@ describe 'register', :type => :aruba do
     it 'outputs invalid configuration error' do
       expect(last_command_started).to have_output(/Failed to load application configuration/)
       expect(last_command_started).to have_output(
-              /Storage location 'loc1' specifies invalid 'path' property: Path must not be empty/)
+              /Storage location 'loc1' specifies invalid location 'path' property: Path must not be empty/)
       expect(last_command_started).to have_exit_status(1)
     end
   end

--- a/spec/features/rsync_replication_feature_spec.rb
+++ b/spec/features/rsync_replication_feature_spec.rb
@@ -68,7 +68,7 @@ describe 'rsync replication service', :type => :aruba do
       end
 
       it 'reports failure and does not replicate' do
-        expect(last_command_started).to have_output(/Storage location 'loc2' specifies a 'metadata_path' directory which does not exist/)
+        expect(last_command_started).to have_output(/Storage location 'loc2' specifies a metadata 'path' directory which does not exist/)
         expect(last_command_started).to have_exit_status(1)
 
         repl_path = File.join(path_dir2, File.basename(file_path))

--- a/spec/features/validate_application_config_spec.rb
+++ b/spec/features/validate_application_config_spec.rb
@@ -57,7 +57,7 @@ describe 'validate_config', :type => :aruba do
     it 'outputs invalid configuration error' do
       expect(last_command_started).to have_output(/Application configuration invalid/)
       expect(last_command_started).to have_output(
-              /Storage location 'loc1' specifies invalid 'path' property: Path must not be empty/)
+              /Storage location 'loc1' specifies invalid location 'path' property: Path must not be empty/)
       expect(last_command_started).to have_exit_status(1)
     end
   end
@@ -78,7 +78,7 @@ describe 'validate_config', :type => :aruba do
 
     it 'outputs path does not exist configuration error' do
       expect(last_command_started).to have_output(/Application configuration invalid/)
-      expect(last_command_started).to have_output(/Storage location 'loc1' specifies a 'path' directory which does not exist/)
+      expect(last_command_started).to have_output(/Storage location 'loc1' specifies a location 'path' directory which does not exist/)
       expect(last_command_started).to have_exit_status(1)
     end
   end
@@ -233,7 +233,7 @@ describe 'validate_config', :type => :aruba do
 
     it 'reports all errors' do
       expect(last_command_started).to have_output(/Application configuration invalid/)
-      expect(last_command_started).to have_output(/Storage location 'loc1' specifies invalid 'metadata_path' property/)
+      expect(last_command_started).to have_output(/Metadata location must be present for location 'loc1'/)
       expect(last_command_started).to have_output(/Service definition 'serv1' must specify a 'work_script' property/)
       expect(last_command_started).to have_output(/Mapping specifies value 'serv_none'/)
       expect(last_command_started).to have_exit_status(1)

--- a/spec/longleaf/models/filesystem_metadata_location_spec.rb
+++ b/spec/longleaf/models/filesystem_metadata_location_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'longleaf/models/filesystem_metadata_location'
+require 'longleaf/errors'
+require 'fileutils'
+require 'tempfile'
+
+describe Longleaf::FilesystemMetadataLocation do
+  describe '.initialize' do
+    context 'with no config' do
+      it { expect { build(:metadata_location, config: nil) }.to raise_error(ArgumentError) }
+    end
+    context 'with no path' do
+      it { expect { build(:metadata_location, path: nil) }.to raise_error(ArgumentError) }
+    end
+  end
+
+  describe '.path' do
+    let(:location) { build(:metadata_location) }
+
+    it { expect(location.path).to eq '/metadata/path/' }
+  end
+
+  describe '.metadata_path_for' do
+    let(:location) { build(:metadata_location) }
+
+    context 'absolute path' do
+      let(:file_path) { '/some/path/to/file' }
+
+      it { expect { location.metadata_path_for(file_path) }.to raise_error(ArgumentError, /File path must be relative/ ) }
+    end
+
+    context 'nil path' do
+      let(:file_path) { nil }
+
+      it { expect { location.metadata_path_for(file_path) }.to raise_error(ArgumentError, /file_path parameter is required/ ) }
+    end
+
+    context 'empty path' do
+      let(:file_path) { '' }
+
+      it { expect(location.metadata_path_for(file_path)).to eq '/metadata/path/' }
+    end
+
+    context 'relative file path' do
+      let(:file_path) { 'to/file.txt' }
+
+      it { expect(location.metadata_path_for(file_path)).to eq '/metadata/path/to/file.txt-llmd.yaml' }
+    end
+
+    context 'relative directory path' do
+      let(:file_path) { 'to/directory/' }
+
+      it { expect(location.metadata_path_for(file_path)).to eq '/metadata/path/to/directory/' }
+    end
+  end
+
+  describe '.digests' do
+    context 'with nil digests' do
+      let(:location) { build(:metadata_location, digests: nil) }
+
+      it { expect(location.digests).to eq [] }
+    end
+
+    context 'with no digests' do
+      let(:location) { build(:metadata_location, digests: []) }
+
+      it { expect(location.digests).to eq [] }
+    end
+
+    context 'with string digest' do
+      let(:location) { build(:metadata_location, digests: 'sha1') }
+
+      it { expect(location.digests).to contain_exactly('sha1') }
+    end
+
+    context 'with array digest' do
+      let(:location) { build(:metadata_location, digests: ['sha1']) }
+
+      it { expect(location.digests).to contain_exactly('sha1') }
+    end
+
+    context 'with non-normalized case array digest' do
+      let(:location) { build(:metadata_location, digests: ['SHA1', 'Sha512']) }
+
+      it { expect(location.digests).to contain_exactly('sha1', 'sha512') }
+    end
+
+    context 'with multiple digests' do
+      let(:location) { build(:metadata_location, digests: ['sha1', 'sha512']) }
+
+      it { expect(location.digests).to contain_exactly('sha1', 'sha512') }
+    end
+
+    context 'with invalid digest' do
+      let(:location) { build(:metadata_location, digests: ['indigestion']) }
+
+      it { expect { location.get_metadata_path_for }.to raise_error(Longleaf::InvalidDigestAlgorithmError) }
+    end
+  end
+
+  describe '.relativize' do
+    let(:location) { build(:metadata_location) }
+
+    context 'path not in location' do
+      let(:file_path) { '/some/other/path/file' }
+
+      it { expect { location.relativize(file_path) }.to raise_error(ArgumentError, /must be contained by this location/ ) }
+    end
+
+    context 'relative path' do
+      let(:file_path) { 'path/file' }
+
+      it { expect(location.relativize(file_path)).to eq file_path }
+    end
+
+    context 'path in location' do
+      let(:file_path) { '/metadata/path/sub/myfile.txt-llmd.yaml' }
+
+      it { expect(location.relativize(file_path)).to eq 'sub/myfile.txt-llmd.yaml' }
+    end
+  end
+
+  describe '.relative_file_path_for' do
+    let(:location) { build(:metadata_location) }
+
+    context 'path not in location' do
+      let(:md_path) { '/some/other/path/file.txt-llmd.yaml' }
+
+      it { expect { location.relative_file_path_for(md_path) }.to raise_error(ArgumentError, /must be contained by this location/ ) }
+    end
+
+    context 'relative path' do
+      let(:md_path) { 'to/file.txt-llmd.yaml' }
+
+      it { expect(location.relative_file_path_for(md_path)).to eq 'to/file.txt' }
+    end
+
+    context 'absolute path in location' do
+      let(:md_path) { '/metadata/path/to/file.txt-llmd.yaml' }
+
+      it { expect(location.relative_file_path_for(md_path)).to eq 'to/file.txt' }
+    end
+
+    context 'directory in location' do
+      let(:md_path) { '/metadata/path/to/directory/' }
+
+      it { expect(location.relative_file_path_for(md_path)).to eq 'to/directory/' }
+    end
+  end
+
+  describe '.contains?' do
+    let(:location) { build(:metadata_location) }
+
+    context 'path in location' do
+      let(:file_path) { '/metadata/path/sub/myfile.txt' }
+
+      it { expect(location.contains?(file_path)).to be true }
+    end
+
+    context 'path not in location' do
+      let(:file_path) { '/other/path/to/somefile.txt' }
+
+      it { expect(location.contains?(file_path)).to be false }
+    end
+  end
+end

--- a/spec/longleaf/services/application_config_deserializer_spec.rb
+++ b/spec/longleaf/services/application_config_deserializer_spec.rb
@@ -77,7 +77,7 @@ describe Longleaf::ApplicationConfigDeserializer do
         loc = result.location_manager.locations['loc1']
 
         expect(loc.path).to eq path_dir + '/'
-        expect(loc.metadata_path).to eq md_dir + '/'
+        expect(loc.metadata_location.path).to eq md_dir + '/'
       end
 
       context 'with relative path to config file' do
@@ -90,7 +90,7 @@ describe Longleaf::ApplicationConfigDeserializer do
           loc = result.location_manager.locations['loc1']
 
           expect(loc.path).to eq path_dir + '/'
-          expect(loc.metadata_path).to eq md_dir + '/'
+          expect(loc.metadata_location.path).to eq md_dir + '/'
         end
       end
     end
@@ -119,7 +119,7 @@ describe Longleaf::ApplicationConfigDeserializer do
         loc = result.location_manager.locations['loc1']
 
         expect(loc.path).to eq path_pathname.to_s + '/'
-        expect(loc.metadata_path).to eq md_pathname.to_s + '/'
+        expect(loc.metadata_location.path).to eq md_pathname.to_s + '/'
       end
     end
 

--- a/spec/longleaf/services/application_config_validator_spec.rb
+++ b/spec/longleaf/services/application_config_validator_spec.rb
@@ -29,7 +29,7 @@ describe Longleaf::ApplicationConfigValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /'loc1' specifies invalid 'path' property/) }
+      it { fails_validation_with_error(validator, /'loc1' specifies invalid location 'path' property/) }
     end
 
     context 'invalid service configuration' do
@@ -79,7 +79,7 @@ describe Longleaf::ApplicationConfigValidator do
 
       it 'reports all failures' do
         fails_validation_with_error(validator,
-            /'loc1' specifies invalid 'path' property/,
+            /'loc1' specifies invalid location 'path' property/,
             /'serv1' must specify a 'work_script' property/,
             /'serv_none', but no services with that name exist/)
       end

--- a/spec/longleaf/services/storage_location_manager_spec.rb
+++ b/spec/longleaf/services/storage_location_manager_spec.rb
@@ -36,7 +36,7 @@ describe Longleaf::StorageLocationManager do
 
         expect(location.name).to eq 's_loc'
         expect(location.path).to eq '/file/path/'
-        expect(location.metadata_path).to eq '/metadata/path/'
+        expect(location.metadata_location.path).to eq '/metadata/path/'
       end
     end
 
@@ -57,7 +57,7 @@ describe Longleaf::StorageLocationManager do
 
         expect(location.name).to eq 'loc1'
         expect(location.path).to eq '/file/path1/'
-        expect(location.metadata_path).to eq '/metadata/path1/'
+        expect(location.metadata_location.path).to eq '/metadata/path1/'
       end
 
       it 'returns location loc2' do
@@ -65,7 +65,7 @@ describe Longleaf::StorageLocationManager do
 
         expect(location.name).to eq 'loc2'
         expect(location.path).to eq '/file/path2/'
-        expect(location.metadata_path).to eq '/metadata/path2/'
+        expect(location.metadata_location.path).to eq '/metadata/path2/'
       end
     end
 
@@ -77,7 +77,7 @@ describe Longleaf::StorageLocationManager do
         location = manager.locations['loc1']
 
         expect(location.name).to eq 'loc1'
-        expect(location.metadata_digests).to contain_exactly('sha1')
+        expect(location.metadata_location.digests).to contain_exactly('sha1')
       end
     end
 
@@ -89,7 +89,7 @@ describe Longleaf::StorageLocationManager do
         location = manager.locations['loc1']
 
         expect(location.name).to eq 'loc1'
-        expect(location.metadata_digests).to contain_exactly('sha1', 'sha256')
+        expect(location.metadata_location.digests).to contain_exactly('sha1', 'sha256')
       end
     end
   end

--- a/spec/longleaf/services/storage_location_validator_spec.rb
+++ b/spec/longleaf/services/storage_location_validator_spec.rb
@@ -50,21 +50,27 @@ describe Longleaf::StorageLocationValidator do
     context 'with location missing path' do
       let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: nil, md_path: md_dir1).get }
 
-      it { fails_validation_with_error(validator, /'path' property: Path must not be empty/) }
+      it { fails_validation_with_error(validator, /location 'path' property: Path must not be empty/) }
+    end
+
+    context 'with location missing metadata config' do
+      let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: path_dir1, md_path: nil).get }
+
+      it { fails_validation_with_error(validator, /Metadata location must be present for location/) }
     end
 
     context 'with location missing metadata path' do
-      let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: path_dir1, md_path: nil).get }
+      let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: path_dir1, md_path: '').get }
 
-      it { fails_validation_with_error(validator, /'metadata_path' property: Path must not be empty/) }
+      it { fails_validation_with_error(validator, /metadata 'path' property: Path must not be empty/) }
     end
 
     context 'with location missing path and metadata path' do
       let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: nil, md_path: nil).get }
 
       it 'returns errors for path and metadata path' do
-        fails_validation_with_error(validator, /'path' property: Path must not be empty/,
-            /'metadata_path' property: Path must not be empty/)
+        fails_validation_with_error(validator, /location 'path' property: Path must not be empty/,
+            /Metadata location must be present for location/)
       end
     end
 
@@ -86,19 +92,19 @@ describe Longleaf::StorageLocationValidator do
     context 'with location with non-absolute path' do
       let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: 'path/').get }
 
-      it { fails_validation_with_error(validator, /'path' property: Path must be absolute/) }
+      it { fails_validation_with_error(validator, /location 'path' property: Path must be absolute/) }
     end
 
     context 'with location with path modifiers' do
       let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: '/file/../path/').get }
 
-      it { fails_validation_with_error(validator, /'path' property: Path must not contain any relative modifiers/) }
+      it { fails_validation_with_error(validator, /location 'path' property: Path must not contain any relative modifiers/) }
     end
 
     context 'with location with non-absolute metadata_path' do
       let(:config) { ConfigBuilder.new.with_location(name: 'loc1', path: path_dir1, md_path: 'md_path/').get }
 
-      it { fails_validation_with_error(validator, /'metadata_path' property: Path must be absolute/) }
+      it { fails_validation_with_error(validator, /metadata 'path' property: Path must be absolute/) }
     end
 
     context 'with location with non-hash location' do
@@ -115,7 +121,7 @@ describe Longleaf::StorageLocationValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /defines property metadata_path.*overlaps with another configured path/) }
+      it { fails_validation_with_error(validator, /defines property metadata path.*overlaps with another configured path/) }
     end
 
     context 'with location path contained by another location path' do
@@ -129,7 +135,7 @@ describe Longleaf::StorageLocationValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /defines property path.*overlaps with another configured path/) }
+      it { fails_validation_with_error(validator, /defines property location path.*overlaps with another configured path/) }
     end
 
     context 'with location path contained by another location path without trailing slash' do
@@ -143,7 +149,7 @@ describe Longleaf::StorageLocationValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /defines property path.*overlaps with another configured path/) }
+      it { fails_validation_with_error(validator, /defines property location path.*overlaps with another configured path/) }
     end
 
     # Ensuring problem is caught in either direction
@@ -158,7 +164,7 @@ describe Longleaf::StorageLocationValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /defines property path.*overlaps with another configured path/) }
+      it { fails_validation_with_error(validator, /defines property location path.*overlaps with another configured path/) }
     end
 
     context 'with location path contained by another location metadata_path' do
@@ -172,7 +178,7 @@ describe Longleaf::StorageLocationValidator do
           .get
       }
 
-      it { fails_validation_with_error(validator, /defines property metadata_path.*overlaps with another configured path/) }
+      it { fails_validation_with_error(validator, /defines property metadata path.*overlaps with another configured path/) }
     end
 
     context 'location with invalid name' do
@@ -217,7 +223,7 @@ describe Longleaf::StorageLocationValidator do
           .with_location(name: 'loc1', path: path_dir1, md_path: md_dir1).get
       }
 
-      it { fails_validation_with_error(validator, /Storage location 'loc1' specifies a 'path' directory which does not exist/) }
+      it { fails_validation_with_error(validator, /Storage location 'loc1' specifies a location 'path' directory which does not exist/) }
     end
 
     context 'with metadata path that does not exist' do
@@ -230,7 +236,7 @@ describe Longleaf::StorageLocationValidator do
           .with_location(name: 'loc1', path: path_dir1, md_path: md_dir1).get
       }
 
-      it { fails_validation_with_error(validator, /Storage location 'loc1' specifies a 'metadata_path' directory which does not exist/) }
+      it { fails_validation_with_error(validator, /Storage location 'loc1' specifies a metadata 'path' directory which does not exist/) }
     end
   end
 end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/LEF-68
* Refactor storage location into StorageLocation and MetadataLocation. 
* Add Filesystem implementation of each. Implementation is selected based off of 'type' parameter in config. 
* Metadata config now optionally can be a hash nested inside the location, in order to specify more attributes (this is a breaking config change since the property was renamed from "metadata_path" to "metadata")

Config would now look like:
```
locations:
  loc_1:
    path: /path/to/original/files/
    type: filesystem # this is the default
    metadata: # this can be supplied as a string instead, but only the path can be supplied
       path: /Users/bbpennel/temp/ll_test/metadata/
       type: filesystem # default
       digests: md5 #optional
```