### PR TITLE
Treat digest keys as case insensitive

### DIFF
--- a/lib/longleaf/helpers/case_insensitive_hash.rb
+++ b/lib/longleaf/helpers/case_insensitive_hash.rb
@@ -1,0 +1,38 @@
+module Longleaf
+  # Hash subclass which provides case insensitive keys, where keys are always downcased.
+  class CaseInsensitiveHash < Hash
+    def [](key)
+      super _insensitive(key)
+    end
+
+    def []=(key, value)
+      super _insensitive(key), value
+    end
+
+    def delete(key)
+      super _insensitive(key)
+    end
+
+    def has_key?(key)
+      super _insensitive(key)
+    end
+
+    def merge(other_hash)
+      super other_hash.map {|k, v| [_insensitive(k), v] }.to_h
+    end
+
+    def merge!(other_hash)
+      super other_hash.map {|k, v| [_insensitive(k), v] }.to_h
+    end
+
+    # Cause this hash to serialize as a regular hash to avoid deserialization failures
+    def encode_with coder
+      coder.represent_map nil, self
+    end
+
+    protected
+    def _insensitive(key)
+      key.respond_to?(:downcase) ? key.downcase : key
+    end
+  end
+end

--- a/lib/longleaf/models/metadata_record.rb
+++ b/lib/longleaf/models/metadata_record.rb
@@ -1,5 +1,6 @@
 require_relative 'md_fields'
 require_relative 'service_record'
+require 'longleaf/helpers/case_insensitive_hash'
 
 module Longleaf
   # Metadata record for a single file
@@ -22,7 +23,8 @@ module Longleaf
       @properties = properties || Hash.new
       @registered = registered
       @deregistered = deregistered
-      @checksums = checksums || Hash.new
+      @checksums = CaseInsensitiveHash.new
+      @checksums.merge!(checksums) unless checksums.nil?
       @services = services || Hash.new
       @file_size = file_size
       @last_modified = last_modified

--- a/spec/longleaf/models/metadata_record_spec.rb
+++ b/spec/longleaf/models/metadata_record_spec.rb
@@ -36,7 +36,7 @@ describe Longleaf::MetadataRecord do
       it 'adds a checksum' do
         record.checksums['MD5'] = 'digest'
 
-        expect(record.checksums).to include('MD5' => 'digest')
+        expect(record.checksums).to include('md5' => 'digest')
       end
 
       it 'removes a checksum' do
@@ -47,10 +47,18 @@ describe Longleaf::MetadataRecord do
     end
 
     context 'with checksum properties' do
-      let(:expected_checksums) { {'SHA1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83' } }
+      let(:expected_checksums) { {'sha1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83' } }
       let(:record) { build(:metadata_record, checksums: expected_checksums ) }
 
       it { expect(record.checksums).to include(expected_checksums) }
+      it { expect(record.checksums.length).to eq 1 }
+    end
+
+    context 'with caps checksum properties' do
+      let(:expected_checksums) { {'SHA1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83' } }
+      let(:record) { build(:metadata_record, checksums: expected_checksums ) }
+
+      it { expect(record.checksums).to include('sha1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83') }
       it { expect(record.checksums.length).to eq 1 }
     end
   end

--- a/spec/longleaf/services/metadata_deserializer_spec.rb
+++ b/spec/longleaf/services/metadata_deserializer_spec.rb
@@ -88,7 +88,7 @@ describe Longleaf::MetadataDeserializer do
         result = Deserializer.deserialize(file_path: md_file)
 
         expect(result.registered).to eq '2018-01-01T00:00:00.000Z'
-        expect(result.checksums).to include('SHA1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83')
+        expect(result.checksums).to include('sha1' => '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83')
         expect(result.file_size).to eq 1500
         expect(result.last_modified).to eq '2016-01-01T20:38:45Z'
         expect(result.properties['special']).to eq 'value'

--- a/spec/longleaf/services/metadata_serializer_spec.rb
+++ b/spec/longleaf/services/metadata_serializer_spec.rb
@@ -48,7 +48,7 @@ describe Longleaf::MetadataSerializer do
         expect(md.dig(MDF::DATA, MDF::REGISTERED_TIMESTAMP)).to eq '2018-01-01T00:00:00.000Z'
         expect(md.dig(MDF::DATA, MDF::FILE_SIZE)).to eq 1500
         expect(md.dig(MDF::DATA, MDF::LAST_MODIFIED)).to eq '2018-09-20T13:13:23Z'
-        expect(md.dig(MDF::DATA, MDF::CHECKSUMS, 'SHA1')).to eq '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83'
+        expect(md.dig(MDF::DATA, MDF::CHECKSUMS, 'sha1')).to eq '4e1243bd22c66e76c2ba9eddc1f91394e57f9f83'
         expect(md.dig(MDF::DATA, 'other_prop')).to eq 'value'
 
         expect(md.dig(MDF::SERVICES, :service_1, MDF::SERVICE_TIMESTAMP)).to eq '2018-01-01T01:00:00.000Z'
@@ -63,7 +63,7 @@ describe Longleaf::MetadataSerializer do
           digest_path = "#{dest_file.path}.sha1"
 
           expect(File.exist?(digest_path)).to be true
-          expect(IO.read(digest_path)).to eq '4f33fb12b92a6c2f5b24c51a32368f296ccdb844'
+          expect(IO.read(digest_path)).to eq '1b3ff89cbdc5b6ea85c981f78111aae377dfbea1'
         end
       end
 
@@ -74,10 +74,10 @@ describe Longleaf::MetadataSerializer do
           digest_path_sha512 = "#{dest_file.path}.sha512"
 
           expect(File.exist?(digest_path_md5)).to be true
-          expect(IO.read(digest_path_md5)).to eq '51ffda2dbfdbc7f1dabee110f12cdcf1'
+          expect(IO.read(digest_path_md5)).to eq 'cb2c5373318988c9b681a79f67552a2c'
 
           expect(File.exist?(digest_path_sha512)).to be true
-          expect(IO.read(digest_path_sha512)).to eq 'c84a0e05e64082e8fb06162dac465b150a9bfcec440927ef66b8876968ce79a43c10b2ac894f040c2351f861f3427f50e4e37b1a5a072e84e9aa0fabc5a8b845'
+          expect(IO.read(digest_path_sha512)).to eq '5b77efa7db605378a42b273bc0650df1fd7e5db4ab2e735ee8afc7c9a0e1c4836d7bfb942416c83f21def18538937f99051c467504616f2a2a07bcee48fa3031'
         end
       end
     end


### PR DESCRIPTION
* Fix bug where digests keys were case sensitive based on how the client provided them
* Introduces case insensitive hash impl for this purpose