### PR TITLE
LEF-73 - S3 uploads and paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ commands:
             - v1-dependencies-
 
       - run:
+          name: install bundler 1.17
+          command: sudo gem install bundler:1.17.3
+
+      - run:
           name: install dependencies
           command: |
             bin/setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,6 @@ commands:
             - v1-dependencies-
 
       - run:
-          name: install bundler 1.17
-          command: sudo gem install bundler:1.17.3
-
-      - run:
           name: install dependencies
           command: |
             bin/setup
@@ -57,6 +53,11 @@ commands:
 
       - store_artifacts:
           path: coverage
+  install_old_bundler:
+    steps:
+      - run:
+          name: install bundler 1.17
+          command: sudo gem install bundler:1.17.3
 
 jobs:
   test_with_ruby_23:
@@ -79,6 +80,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - install_old_bundler
       - build_and_run_tests
 workflows:
   version: 2.2

--- a/lib/longleaf/helpers/s3_uri_helper.rb
+++ b/lib/longleaf/helpers/s3_uri_helper.rb
@@ -31,7 +31,7 @@ module Longleaf
         return prefix[0..-2]
       end
     end
-    
+
     def self.extract_path(url)
       uri = s3_uri(url)
 
@@ -41,18 +41,18 @@ module Longleaf
       end
 
       path = uri.path
-      return nil if path == '/'
-      
+      return nil if path == '/' || path.empty?
+
       # trim off the first slash
       path = path.partition('/').last
-      
+
       # Determine if the first part of the path is the bucket name
       prefix = matches[1]
       if prefix.nil? || prefix.empty?
         # trim off the bucket name
         path = path.partition('/').last
       end
-      
+
       path
     end
 

--- a/lib/longleaf/helpers/s3_uri_helper.rb
+++ b/lib/longleaf/helpers/s3_uri_helper.rb
@@ -31,6 +31,30 @@ module Longleaf
         return prefix[0..-2]
       end
     end
+    
+    def self.extract_path(url)
+      uri = s3_uri(url)
+
+      matches = ENDPOINT_PATTERN.match(uri.host)
+      if matches.nil?
+        raise ArgumentError.new("Provided URI does match the expected pattern for an S3 URI")
+      end
+
+      path = uri.path
+      return nil if path == '/'
+      
+      # trim off the first slash
+      path = path.partition('/').last
+      
+      # Determine if the first part of the path is the bucket name
+      prefix = matches[1]
+      if prefix.nil? || prefix.empty?
+        # trim off the bucket name
+        path = path.partition('/').last
+      end
+      
+      path
+    end
 
     def self.extract_region(url)
       uri = s3_uri(url)

--- a/lib/longleaf/models/s3_storage_location.rb
+++ b/lib/longleaf/models/s3_storage_location.rb
@@ -43,6 +43,8 @@ module Longleaf
         region = S3UriHelper.extract_region(@path)
         @client_options[:region] = region unless region.nil?
       end
+      
+      @subpath_prefix = S3UriHelper.extract_path(@path)
     end
 
     # @return the storage type for this location
@@ -91,6 +93,24 @@ module Longleaf
           file_path
         end
       end
+    end
+    
+    # Prefixes the provided path with the query path portion of the location's path
+    # after the bucket uri, used to place relative paths into the same sub-URL of a bucket.
+    # For example:
+    # Given a location with 'path' http://example.s3-amazonaws.com/env/test/
+    # Where rel_path = 'path/to/text.txt'
+    # The result would be 'env/test/path/to/text.txt'
+    # @param rel_path relative path to work with
+    # @return the given relative path prefixed with the path portion of the storage location path
+    def relative_to_bucket_path(rel_path)
+      raise ArgumentError.new("Must provide a non-nil path") if rel_path.nil?
+      
+      if @subpath_prefix.nil?
+        return rel_path
+      end
+      
+      @subpath_prefix + rel_path
     end
 
     # @return the bucket used by this storage location

--- a/lib/longleaf/preservation_services/s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/s3_replication_service.rb
@@ -89,7 +89,8 @@ module Longleaf
         # Check that the destination is available because attempting to write
         verify_destination_available(destination, file_rec)
 
-        file_obj = destination.s3_bucket.object(rel_path)
+        rel_to_bucket = destination.relative_to_bucket_path(rel_path)
+        file_obj = destination.s3_bucket.object(rel_to_bucket)
         begin
           file_obj.upload_file(file_rec.path, { :content_md5 => content_md5 })
         rescue Aws::S3::Errors::BadDigest => e

--- a/lib/longleaf/preservation_services/s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/s3_replication_service.rb
@@ -86,7 +86,7 @@ module Longleaf
       content_md5 = get_content_md5(file_rec)
 
       @destinations.each do |destination|
-        # Check that the destination is available because attempting to write
+        # Check that the destination is available before attempting to write
         verify_destination_available(destination, file_rec)
 
         rel_to_bucket = destination.relative_to_bucket_path(rel_path)

--- a/spec/longleaf/models/s3_storage_location_spec.rb
+++ b/spec/longleaf/models/s3_storage_location_spec.rb
@@ -133,7 +133,7 @@ describe Longleaf::S3StorageLocation do
       it { expect { loc1.relativize('https://anotherbucket.s3-amazonaws.com/path/subdir/file.txt') }.to raise_error(ArgumentError) }
     end
   end
-  
+
   describe '.relative_to_bucket_path' do
     context 'bucket in virtual host style with no path' do
       let(:loc1) { build(:s3_storage_location, path: 'http://example.s3-my-region-amazonaws.com/') }
@@ -141,21 +141,21 @@ describe Longleaf::S3StorageLocation do
         expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'path/to/file.txt'
       end
     end
-    
+
     context 'bucket in virtual host style with path' do
       let(:loc1) { build(:s3_storage_location, path: 'http://example.s3-my-region-amazonaws.com/env/test') }
       it 'returns the provided path' do
         expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'env/test/path/to/file.txt'
       end
     end
-    
+
     context 'bucket in path style without additional path' do
       let(:loc1) { build(:s3_storage_location, path: 'http://s3-my-region-amazonaws.com/pathexample/') }
       it 'returns the provided path' do
         expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'path/to/file.txt'
       end
     end
-    
+
     context 'bucket in path style with additional path' do
       let(:loc1) { build(:s3_storage_location, path: 'http://s3-my-region-amazonaws.com/pathexample/env/qa') }
       it 'returns the provided path' do

--- a/spec/longleaf/models/s3_storage_location_spec.rb
+++ b/spec/longleaf/models/s3_storage_location_spec.rb
@@ -133,6 +133,36 @@ describe Longleaf::S3StorageLocation do
       it { expect { loc1.relativize('https://anotherbucket.s3-amazonaws.com/path/subdir/file.txt') }.to raise_error(ArgumentError) }
     end
   end
+  
+  describe '.relative_to_bucket_path' do
+    context 'bucket in virtual host style with no path' do
+      let(:loc1) { build(:s3_storage_location, path: 'http://example.s3-my-region-amazonaws.com/') }
+      it 'returns the provided path' do
+        expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'path/to/file.txt'
+      end
+    end
+    
+    context 'bucket in virtual host style with path' do
+      let(:loc1) { build(:s3_storage_location, path: 'http://example.s3-my-region-amazonaws.com/env/test') }
+      it 'returns the provided path' do
+        expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'env/test/path/to/file.txt'
+      end
+    end
+    
+    context 'bucket in path style without additional path' do
+      let(:loc1) { build(:s3_storage_location, path: 'http://s3-my-region-amazonaws.com/pathexample/') }
+      it 'returns the provided path' do
+        expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'path/to/file.txt'
+      end
+    end
+    
+    context 'bucket in path style with additional path' do
+      let(:loc1) { build(:s3_storage_location, path: 'http://s3-my-region-amazonaws.com/pathexample/env/qa') }
+      it 'returns the provided path' do
+        expect(loc1.relative_to_bucket_path('path/to/file.txt')).to eq 'env/qa/path/to/file.txt'
+      end
+    end
+  end
 
   describe '.get_metadata_path_for' do
     let(:loc1) { build(:s3_storage_location) }

--- a/spec/longleaf/preservation_services/s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/s3_replication_service_spec.rb
@@ -137,7 +137,7 @@ describe Longleaf::S3ReplicationService do
           expect(s3_client.api_requests.size).to eq(2)
           expect(s3_client.api_requests.last[:params]).to include(
                   :bucket => "example",
-                  :key => 'test_file.txt'
+                  :key => 'path/test_file.txt'
                 )
         end
       end
@@ -154,7 +154,7 @@ describe Longleaf::S3ReplicationService do
           expect(s3_client.api_requests.size).to eq(2)
           expect(s3_client.api_requests.last[:params]).to include(
                   :bucket => "example",
-                  :key => 'test_file.txt',
+                  :key => 'path/test_file.txt',
                   :content_md5 => 'mgNkuembtIDdJeHwKEyFVQ=='
                 )
         end
@@ -192,7 +192,7 @@ describe Longleaf::S3ReplicationService do
           expect(s3_client.api_requests.size).to eq(2)
           expect(s3_client.api_requests.last[:params]).to include(
                   :bucket => "example",
-                  :key => 'nested/test_file.txt'
+                  :key => 'path/nested/test_file.txt'
                 )
         end
       end
@@ -228,7 +228,7 @@ describe Longleaf::S3ReplicationService do
           expect(s3_client.api_requests.size).to eq(2)
           expect(s3_client.api_requests.last[:params]).to include(
                   :bucket => "example",
-                  :key => 'test_file.txt'
+                  :key => 'path/test_file.txt'
                 )
 
           s3_client2 = dest2.s3_client


### PR DESCRIPTION
* Switches to using `upload_file` for s3 uploads, which allows for upload of files larger than 5gb. 
   * Behind the scenes, it is calling `put` for files less than the threshold
   * The threshold defaults to 15mb. I have not changed it at this point.
* If an s3 location's path is to a subpath of a bucket, then retain that subpath when uploading files
   * This allows the same bucket to be used for multiple storage locations by giving each a different path prefix, like test, qa, prod, etc.

Note: multipart uploads are transferred in 5mb chunks, which is smaller than my cost estimates. This number is hardcoded into the client:
https://github.com/aws/aws-sdk-ruby/blob/97b28ccf18558fc908fd56f52741cf3329de9869/gems/aws-sdk-s3/lib/aws-sdk-s3/multipart_file_uploader.rb#L10
There does not appear to be a way to override it other than overriding the class.