### PR TITLE
LEF-79 - Register from manifests

### DIFF
--- a/lib/longleaf/candidates/manifest_digest_provider.rb
+++ b/lib/longleaf/candidates/manifest_digest_provider.rb
@@ -1,16 +1,17 @@
 module Longleaf
   # Provides digests for files from a manifest
   class ManifestDigestProvider
-    def initialize(path_to_digests)
-      @path_to_digests = path_to_digests
+    # @param hash which maps file paths to hashs of digests
+    def initialize(digests_mapping)
+      @digests_mapping = digests_mapping
     end
 
     # @param file_path [String] path of file
     # @return hash containing all the manifested digests for the given path, or nil
     def get_digests(file_path)
       # return nil if key not found, in case the hash has default values
-      return nil unless @path_to_digests.key?(file_path)
-      @path_to_digests[file_path]
+      return nil unless @digests_mapping.key?(file_path)
+      @digests_mapping[file_path]
     end
   end
 end

--- a/lib/longleaf/candidates/manifest_digest_provider.rb
+++ b/lib/longleaf/candidates/manifest_digest_provider.rb
@@ -1,0 +1,16 @@
+module Longleaf
+  # Provides digests for files from a manifest
+  class ManifestDigestProvider
+    def initialize(path_to_digests)
+      @path_to_digests = path_to_digests
+    end
+
+    # @param file_path [String] path of file
+    # @return hash containing all the manifested digests for the given path, or nil
+    def get_digests(file_path)
+      # return nil if key not found, in case the hash has default values
+      return nil unless @path_to_digests.key?(file_path)
+      @path_to_digests[file_path]
+    end
+  end
+end

--- a/lib/longleaf/candidates/single_digest_provider.rb
+++ b/lib/longleaf/candidates/single_digest_provider.rb
@@ -1,0 +1,13 @@
+module Longleaf
+  # Provides a single set of digests for files
+  class SingleDigestProvider
+    def initialize(digests)
+      @digests = digests
+    end
+
+    def get_digests(file_path)
+      return nil if @digests.nil?
+      @digests
+    end
+  end
+end

--- a/lib/longleaf/cli.rb
+++ b/lib/longleaf/cli.rb
@@ -9,8 +9,7 @@ require 'longleaf/commands/validate_metadata_command'
 require 'longleaf/commands/register_command'
 require 'longleaf/commands/reindex_command'
 require 'longleaf/commands/preserve_command'
-require 'longleaf/candidates/file_selector'
-require 'longleaf/candidates/registered_file_selector'
+require 'longleaf/helpers/selection_options_parser'
 
 module Longleaf
   # Main commandline interface setup for Longleaf using Thor.
@@ -81,12 +80,32 @@ module Longleaf
 
     desc "register", "Register files with Longleaf"
     shared_options_group(:file_selection)
+    method_option(:manifest,
+        :aliases => "-m",
+        :type => :array,
+        :desc => %q{Checksum manifests of files to register. Supports the following formats:
+          To submit a md5 manifest from a file
+          '-m md5:/path/to/manifest.txt'
+          To read a sha1 manifest from STDIN
+          '-m sha1:@-'
+          To submit multiple manifests from files
+          '-m md5:/path/to/manifest1.txt sha1:/path/to/manifest2.txt'
+          To provide multiple digests via STDIN
+          '-m @-'
+          Where the content in STDIN adheres to the following format:
+          sha1:
+          <digest> <path>
+          ...
+          md5:
+          <digest> <path>
+          ...})
     method_option(:force,
         :type => :boolean,
         :default => false,
         :desc => 'Force the registration of already registered files.')
     method_option(:checksums,
-        :desc => %q{Checksums for the submitted file. Each checksum must be prefaced with an algorithm prefix. Multiple checksums must be comma separated. If multiple files were submitted, they will be provided with the same checksums. For example:
+        :desc => %q{Checksums for the submitted file. Only applicable with the -f option.
+          Each checksum must be prefaced with an algorithm prefix. Multiple checksums must be comma separated. If multiple files were submitted, they will be provided with the same checksums. For example:
           '--checksums "md5:d8e8fca2dc0f896fd7cb4cb0031ba249,sha1:4e1243bd22c66e76c2ba9eddc1f91394e57f9f83"'})
     shared_options_group(:common)
     # Register event command
@@ -96,21 +115,11 @@ module Longleaf
 
       app_config_manager = load_application_config(options)
 
-      file_selector = create_file_selector(options, app_config_manager)
-      if options[:checksums]
-        checksums = options[:checksums]
-        # validate checksum list format, must a comma delimited list of prefix:checksums
-        if /^[^:,]+:[^:,]+(,[^:,]+:[^:,]+)*$/.match(checksums)
-          # convert checksum list into hash with prefix as key
-          checksums = Hash[*checksums.split(/\s*[:,]\s*/)]
-        else
-          logger.failure("Invalid checksums parameter format, see `longleaf help <command>` for more information")
-          exit 1
-        end
-      end
+      file_selector, digest_provider = SelectionOptionsParser.parse_registration_selection_options(
+          options, app_config_manager)
 
       command = RegisterCommand.new(app_config_manager)
-      exit command.execute(file_selector: file_selector, force: options[:force], checksums: checksums)
+      exit command.execute(file_selector: file_selector, force: options[:force], digest_provider: digest_provider)
     end
 
     desc "deregister", "Deregister files with Longleaf"
@@ -126,7 +135,7 @@ module Longleaf
       setup_logger(options)
 
       app_config_manager = load_application_config(options)
-      file_selector = create_registered_selector(options, app_config_manager)
+      file_selector = SelectionOptionsParser.create_registered_selector(options, app_config_manager)
 
       command = DeregisterCommand.new(app_config_manager)
       exit command.execute(file_selector: file_selector, force: options[:force])
@@ -145,7 +154,7 @@ module Longleaf
 
       extend_load_path(options[:load_path])
       app_config_manager = load_application_config(options)
-      file_selector = create_registered_selector(options, app_config_manager)
+      file_selector = SelectionOptionsParser.create_registered_selector(options, app_config_manager)
 
       command = PreserveCommand.new(app_config_manager)
       exit command.execute(file_selector: file_selector, force: options[:force])
@@ -171,7 +180,7 @@ module Longleaf
       setup_logger(options)
 
       app_config_manager = load_application_config(options)
-      file_selector = create_registered_selector(options, app_config_manager)
+      file_selector = SelectionOptionsParser.create_registered_selector(options, app_config_manager)
 
       exit Longleaf::ValidateMetadataCommand.new(app_config_manager).execute(file_selector: file_selector)
     end
@@ -229,22 +238,6 @@ module Longleaf
         if options[:config].nil? || options[:config].empty?
           raise "No value provided for required options '--config'"
         end
-      end
-
-      def create_file_selector(options, app_config_manager, selector_class: FileSelector)
-        file_paths = options[:file]&.split(/\s*,\s*/)
-        storage_locations = options[:location]&.split(/\s*,\s*/)
-
-        begin
-          selector_class.new(file_paths: file_paths, storage_locations: storage_locations, app_config: app_config_manager)
-        rescue ArgumentError => e
-          logger.failure(e.message)
-          exit 1
-        end
-      end
-
-      def create_registered_selector(options, app_config_manager)
-        create_file_selector(options, app_config_manager, selector_class: RegisteredFileSelector)
       end
 
       def extend_load_path(load_paths)

--- a/lib/longleaf/cli.rb
+++ b/lib/longleaf/cli.rb
@@ -86,10 +86,17 @@ module Longleaf
         :desc => %q{Checksum manifests of files to register. Supports the following formats:
           To submit a md5 manifest from a file
           '-m md5:/path/to/manifest.txt'
-          To read a sha1 manifest from STDIN
+
+          To provide a sha1 manifest from STDIN
           '-m sha1:@-'
+          Where the content in STDIN adheres to the format:
+          <digest> <path>
+          <digest> <path>
+          ...
+
           To submit multiple manifests from files
           '-m md5:/path/to/manifest1.txt sha1:/path/to/manifest2.txt'
+
           To provide multiple digests via STDIN
           '-m @-'
           Where the content in STDIN adheres to the following format:

--- a/lib/longleaf/commands/register_command.rb
+++ b/lib/longleaf/commands/register_command.rb
@@ -16,9 +16,9 @@ module Longleaf
     # Execute the register command on the given parameters
     # @param file_selector [FileSelector] selector for files to register
     # @param force [Boolean] force flag
-    # @param checksums [Array] array of checksums
+    # @param digest_provider [DigestProvider] object which provides digests for files being registered
     # @return [Integer] status code
-    def execute(file_selector:, force: false, checksums: nil)
+    def execute(file_selector:, force: false, digest_provider: nil)
       start_time = Time.now
       logger.info('Performing register command')
       begin
@@ -32,7 +32,7 @@ module Longleaf
           file_rec = FileRecord.new(f_path, storage_location)
 
           register_event = RegisterEvent.new(file_rec: file_rec, force: force, app_manager: @app_manager,
-              checksums: checksums)
+              digest_provider: digest_provider)
           track_status(register_event.perform)
         end
       rescue InvalidStoragePathError, StorageLocationUnavailableError => err

--- a/lib/longleaf/events/register_event.rb
+++ b/lib/longleaf/events/register_event.rb
@@ -14,7 +14,7 @@ module Longleaf
     # @param file_rec [FileRecord] file record
     # @param app_manager [ApplicationConfigManager] the application configuration
     # @param force [boolean] if true, then already registered files will be re-registered
-    # @param digest_provider [DigestProvider] object which provides digests for files being registered
+    # @param digest_provider [#get_digests] object which provides digests for files being registered
     def initialize(file_rec:, app_manager:, force: false, digest_provider: nil)
       raise ArgumentError.new('Must provide a file_rec parameter') if file_rec.nil?
       raise ArgumentError.new('Parameter file_rec must be a FileRecord') \

--- a/lib/longleaf/helpers/digest_helper.rb
+++ b/lib/longleaf/helpers/digest_helper.rb
@@ -13,7 +13,7 @@ module Longleaf
     def self.validate_algorithms(algs)
       return if algs.nil?
       if algs.is_a?(String)
-        unless KNOWN_DIGESTS.include?(algs)
+        unless self.is_known_algorithm?(algs)
           raise InvalidDigestAlgorithmError.new("Unknown digest algorithm #{algs}")
         end
       else
@@ -22,6 +22,12 @@ module Longleaf
           raise InvalidDigestAlgorithmError.new("Unknown digest algorithm(s): #{unknown}")
         end
       end
+    end
+
+    # @param [String] identifier of digest algorithm
+    # @return [Boolean] true if the digest is a valid known algorithm
+    def self.is_known_algorithm?(alg)
+      KNOWN_DIGESTS.include?(algs)
     end
 
     # Get a Digest class for the specified algorithm

--- a/lib/longleaf/helpers/digest_helper.rb
+++ b/lib/longleaf/helpers/digest_helper.rb
@@ -24,10 +24,10 @@ module Longleaf
       end
     end
 
-    # @param [String] identifier of digest algorithm
+    # @param alg [String] identifier of digest algorithm
     # @return [Boolean] true if the digest is a valid known algorithm
     def self.is_known_algorithm?(alg)
-      KNOWN_DIGESTS.include?(algs)
+      KNOWN_DIGESTS.include?(alg)
     end
 
     # Get a Digest class for the specified algorithm

--- a/lib/longleaf/helpers/selection_options_parser.rb
+++ b/lib/longleaf/helpers/selection_options_parser.rb
@@ -1,0 +1,162 @@
+require 'longleaf/candidates/file_selector'
+require 'longleaf/candidates/registered_file_selector'
+require 'longleaf/candidates/manifest_digest_provider'
+require 'longleaf/candidates/single_digest_provider'
+
+module Longleaf
+  # Helper for parsing manifest inputs used for registration
+  class SelectionOptionsParser
+    extend Longleaf::Logging
+
+    # Parses the provided options to construct a file selector and digest provider for
+    # use in registration commands.
+    # @param options [Hash] command options
+    # @param app_config_manager [ApplicationConfigManager] app config manager
+    # @return The file select and digest provider.
+    def self.parse_registration_selection_options(options, app_config_manager)
+      there_can_only_be_one("Only one of the following selection options may be provided: -m, -f, -s",
+          options, :file, :manifest, :location)
+
+      if !options[:manifest].nil?
+        path_to_digests = self.manifests_to_digest_mapping(options[:manifest])
+        selector = FileSelector.new(file_paths: path_to_digests.keys, app_config: app_config_manager)
+        digest_provider = ManifestDigestProvider.new(path_to_digests)
+      elsif !options[:file].nil?
+        if options[:checksums]
+          checksums = options[:checksums]
+          # validate checksum list format, must a comma delimited list of prefix:checksums
+          if /^[^:,]+:[^:,]+(,[^:,]+:[^:,]+)*$/.match(checksums)
+            # convert checksum list into hash with prefix as key
+            checksums = Hash[*checksums.split(/\s*[:,]\s*/)]
+            digest_provider = SingleDigestProvider.new(checksums)
+          else
+            logger.failure("Invalid checksums parameter format, see `longleaf help <command>` for more information")
+            exit 1
+          end
+        end
+
+        file_paths = options[:file].split(/\s*,\s*/)
+        selector = FileSelector.new(file_paths: file_paths, app_config: app_config_manager)
+      elsif !options[:location].nil?
+        storage_locations = options[:location].split(/\s*,\s*/)
+        selector = FileSelector.new(storage_locations: storage_locations, app_config: app_config_manager)
+        digest_provider = SingleDigestProvider.new(nil)
+      else
+        logger.failure("Must provide one of the following file selection options: -f, l, or -m")
+        exit 1
+      end
+
+      [selector, digest_provider]
+    end
+
+    def self.there_can_only_be_one(failure_msg, options, *names)
+      got_one = false
+      names.each do |name|
+        if !options[name].nil?
+          if got_one
+            logger.failure(failure_msg)
+            exit 1
+          end
+          got_one = true
+        end
+      end
+    end
+
+    # Parses the provided manifest options, reading the contents of the manifests to produce
+    # a mapping from files to one or more algorithms.
+    # @param manifest_vals [Array] List of manifest option values. They may be in one of the following formats:
+    #       <alg_name>:<manifest_path> OR <alg_name>:@-
+    #.      <manifest_path> OR @-
+    # @return a hash containing the aggregated contents of the provided manifests. The keys are
+    #    paths to manifested files. The values are hashes, mapping digest algorithms to digest values.
+    def self.manifests_to_digest_mapping(manifest_vals)
+      alg_manifest_pairs = []
+      # interpret option inputs into a list of algorithms to manifest sources
+      manifest_vals.each do |manifest_val|
+        if manifest_val.include?(':')
+          manifest_parts = manifest_val.split(':', 2)
+          alg_manifest_pairs << manifest_parts
+        else
+          # algorithm no specified in option value
+          alg_manifest_pairs << [nil, manifest_val]
+        end
+      end
+      if alg_manifest_pairs.select { |mpair| mpair[1] == '@-' }.count > 1
+        self.fail("Cannot specify more than one manifest from STDIN")
+      end
+
+      # read the provided manifests to build a mapping from file uri to all supplied digests
+      path_to_digests = Hash.new { |h,k| h[k] = Hash.new }
+      alg_manifest_pairs.each do |mpair|
+        source_stream = nil
+        # Determine if reading from a manifest file or stdin
+        if mpair[1] == '@-'
+          source_stream = $stdin
+        else
+          source_stream = File.new(mpair[1])
+        end
+
+        current_alg = mpair[0]
+        if current_alg.nil?
+          # No algorithm specified, manifest must specify algorithms internally using headers
+          source_stream.each_line do |line|
+            line = line.strip
+            if /[a-zA-Z0-9]+:/ =~ line
+              # Found a digest algorithm header, assuming succeeding entries are of this type
+              current_alg = line.chomp(':')
+              # Verify that the digest algorithm is known to longleaf
+              DigestHelper.validate_algorithms(current_alg)
+            else
+              if current_alg.nil?
+                self.fail("Manifest with unknown checksums encountered, an algorithm must be specified")
+              end
+              entry_parts = line.split(' ', 2)
+              if entry_parts.length != 2
+                self.fail("Invalid manifest entry: #{line}")
+              end
+
+              path_to_digests[entry_parts[1]][current_alg] = entry_parts[0]
+            end
+          end
+        else
+          # Verify that the selected digest algorithm is known to longleaf
+          DigestHelper.validate_algorithms(current_alg)
+
+          # algorithm stated in option, assume all digests in manifest are of this type
+          source_stream.each_line do |line|
+            line = line.strip
+            entry_parts = line.split(' ', 2)
+            if entry_parts.length != 2
+              self.fail("Invalid manifest entry: #{line}")
+            end
+
+            path_to_digests[entry_parts[1]][current_alg] = entry_parts[0]
+          end
+        end
+      end
+
+      path_to_digests
+    end
+
+    # Parses the provided options to create a selector for registered files
+    # @param options [Hash] command options
+    # @param app_config_manager [ApplicationConfigManager] app config manager
+    # @return selector
+    def self.create_registered_selector(options, app_config_manager)
+      file_paths = options[:file]&.split(/\s*,\s*/)
+      storage_locations = options[:location]&.split(/\s*,\s*/)
+
+      begin
+        RegisteredFileSelector.new(file_paths: file_paths, storage_locations: storage_locations, app_config: app_config_manager)
+      rescue ArgumentError => e
+        logger.failure(e.message)
+        exit 1
+      end
+    end
+
+    def self.fail(message)
+      logger.failure(message)
+      exit 1
+    end
+  end
+end

--- a/lib/longleaf/preservation_services/rsync_replication_service.rb
+++ b/lib/longleaf/preservation_services/rsync_replication_service.rb
@@ -4,6 +4,7 @@ require 'longleaf/errors'
 require 'longleaf/models/file_record'
 require 'longleaf/models/service_fields'
 require 'longleaf/events/register_event'
+require 'longleaf/candidates/single_digest_provider'
 require 'open3'
 
 module Longleaf
@@ -174,7 +175,7 @@ module Longleaf
       register_event = RegisterEvent.new(file_rec: dest_file_rec,
           app_manager: @app_manager,
           force: true,
-          checksums: file_rec.metadata_record.checksums)
+          digest_provider: SingleDigestProvider.new(file_rec.metadata_record.checksums))
       register_event.perform
     end
   end

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -166,7 +166,7 @@ describe 'register', :type => :aruba do
       let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
 
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -s 'loc1' --log-level 'DEBUG'")
+        run_command_and_stop("longleaf register -c #{config_path} -s 'loc1' --log-level 'DEBUG'", fail_on_error: false)
       end
 
       it 'registers both files' do
@@ -229,10 +229,209 @@ describe 'register', :type => :aruba do
         expect(last_command_started).to have_exit_status(0)
       end
     end
+
+    context 'register multiple from checksum manifest' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest.txt',
+          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}'", fail_on_error: false)
+      end
+
+      it 'registers the files with digest' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        md_rec1 = get_metadata_record(file_path, md_dir)
+        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        md_rec2 = get_metadata_record(file_path2, md_dir)
+        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register multiple files with multiple checks from multiple manifests' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
+
+      let!(:manifest_path2) { create_test_file(dir: path_dir, name: 'manifest2.txt',
+          content: "9f753c302ffa359ddb9a93fe979d6de1   #{file_path}\n" +
+                   "ce6320a83ead310ae30d43ae0f338bcc   #{file_path2}\n") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m sha1:#{manifest_path} md5:#{manifest_path2}", fail_on_error: false)
+      end
+
+      it 'registers the files with digests' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        md_rec1 = get_metadata_record(file_path, md_dir)
+        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        md_rec2 = get_metadata_record(file_path2, md_dir)
+        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect(md_rec2.checksums['md5']).to eq 'ce6320a83ead310ae30d43ae0f338bcc'
+
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register multiple files with multiple checks from combined manifest' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "sha1:\n" +
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n" +
+                   "md5:\n" +
+                   "9f753c302ffa359ddb9a93fe979d6de1   #{file_path}"
+                   ) }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m #{manifest_path}", fail_on_error: false)
+      end
+
+      it 'registers the files with digests' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        md_rec1 = get_metadata_record(file_path, md_dir)
+        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        md_rec2 = get_metadata_record(file_path2, md_dir)
+        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect(md_rec2.checksums).not_to include('md5')
+
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register from manifest without specifying algorithm' do
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest.txt',
+          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m #{manifest_path}", fail_on_error: false)
+      end
+
+      it 'fails to register' do
+        expect(last_command_started).to have_output(/FAILURE: Manifest with unknown checksums encountered, an algorithm must be specified/)
+        expect(metadata_created(file_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register files from piped checksum manifest' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
+
+      before do
+        run_command("longleaf register -c #{config_path} -m sha1:@-", fail_on_error: false)
+        pipe_in_file(manifest_path)
+        close_input
+      end
+
+      it 'registers the files with digest' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        md_rec1 = get_metadata_record(file_path, md_dir)
+        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        md_rec2 = get_metadata_record(file_path2, md_dir)
+        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register files from piped combined manifest' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "sha1:\n" +
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n" +
+                   "md5:\n" +
+                   "9f753c302ffa359ddb9a93fe979d6de1   #{file_path}"
+                   ) }
+
+      before do
+        run_command("longleaf register -c #{config_path} -m @-", fail_on_error: false)
+        pipe_in_file(manifest_path)
+        close_input
+      end
+
+      it 'registers the files with digest' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        md_rec1 = get_metadata_record(file_path, md_dir)
+        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        md_rec2 = get_metadata_record(file_path2, md_dir)
+        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect(md_rec2.checksums).not_to include('md5')
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register files from multiple stdin manifests' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
+
+      before do
+        run_command("longleaf register -c #{config_path} -m sha1:@- md5:@-", fail_on_error: false)
+        pipe_in_file(manifest_path)
+        close_input
+      end
+
+      it 'fails to registers files' do
+        expect(last_command_started).to have_output(/FAILURE: Cannot specify more than one manifest from STDIN/)
+        expect(metadata_created(file_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register files from invalid manifest' do
+      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
+      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
+          content: "what is\n" +
+                   "even happening\n" +
+                   "here") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m sha1:#{manifest_path}", fail_on_error: false)
+      end
+
+      it 'fails to registers files' do
+        expect(last_command_started).to have_output(/FAILURE: Invalid manifest entry: here/)
+        expect(metadata_created(file_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    # test from stdin sha1:-
+    # test from stdin -
+    # test failure from invalid manifest format
+    # test failure from multiple stdin
+  end
+
+  def get_metadata_record_path(file_path, md_dir)
+    File.join(md_dir, File.basename(file_path) + Longleaf::MetadataSerializer::metadata_suffix)
+  end
+
+  def get_metadata_record(file_path, md_dir)
+    Longleaf::MetadataDeserializer.deserialize(file_path: get_metadata_record_path(file_path, md_dir))
   end
 
   def metadata_created(file_path, md_dir)
-    metadata_path = File.join(md_dir, File.basename(file_path) + Longleaf::MetadataSerializer::metadata_suffix)
-    File.exist?(metadata_path)
+    File.exist?(get_metadata_record_path(file_path, md_dir))
+  end
+
+  def metadata_contains_digest(file_path, md_dir, alg, digest)
+    metadata_path = get_metadata_record_path(file_path, md_dir)
+    md_rec = Longleaf::MetadataDeserializer.deserialize(file_path: metadata_path)
+    md_rec.checksums[alg]
   end
 end

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -65,6 +65,7 @@ describe 'register', :type => :aruba do
         .write_to_yaml_file
     }
     let!(:file_path) { create_test_file(dir: path_dir) }
+    let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
 
     context 'empty file path' do
       before do
@@ -147,8 +148,6 @@ describe 'register', :type => :aruba do
     end
 
     context 'register multiple files' do
-      let(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-
       before do
         run_command_and_stop("longleaf register -c #{config_path} -f '#{file_path},#{file_path2}'")
       end
@@ -163,8 +162,6 @@ describe 'register', :type => :aruba do
     end
 
     context 'register multiple files by storage location' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-
       before do
         run_command_and_stop("longleaf register -c #{config_path} -s 'loc1' --log-level 'DEBUG'", fail_on_error: false)
       end
@@ -179,8 +176,6 @@ describe 'register', :type => :aruba do
     end
 
     context 'register directory of files' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-
       before do
         run_command_and_stop("longleaf register -c #{config_path} -f '#{path_dir}/' --log_level DEBUG", fail_on_error: false)
       end
@@ -213,7 +208,7 @@ describe 'register', :type => :aruba do
 
       it 'registers the file' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        expect(metadata_created(file_path, md_dir)).to be true
+        expect_digests(file_path, md5: 'digest')
         expect(last_command_started).to have_exit_status(0)
       end
     end
@@ -225,15 +220,15 @@ describe 'register', :type => :aruba do
 
       it 'registers the file' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        expect(metadata_created(file_path, md_dir)).to be true
+        expect_digests(file_path, sha1: 'anotherdigest',
+                                  md5: 'digest')
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register multiple from checksum manifest' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest.txt',
-          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
 
       before do
@@ -242,24 +237,22 @@ describe 'register', :type => :aruba do
 
       it 'registers the files with digest' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        md_rec1 = get_metadata_record(file_path, md_dir)
-        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect_digests(file_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a')
         expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
         md_rec2 = get_metadata_record(file_path2, md_dir)
-        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register multiple files with multiple checks from multiple manifests' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
-                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}") }
 
-      let!(:manifest_path2) { create_test_file(dir: path_dir, name: 'manifest2.txt',
-          content: "9f753c302ffa359ddb9a93fe979d6de1   #{file_path}\n" +
-                   "ce6320a83ead310ae30d43ae0f338bcc   #{file_path2}\n") }
+      let!(:manifest_path2) { create_manifest_file(
+                   "9f753c302ffa359ddb9a93fe979d6de1   #{file_path}\n" +
+                   "ce6320a83ead310ae30d43ae0f338bcc   #{file_path2}") }
 
       before do
         run_command_and_stop("longleaf register -c #{config_path} -m sha1:#{manifest_path} md5:#{manifest_path2}", fail_on_error: false)
@@ -267,22 +260,19 @@ describe 'register', :type => :aruba do
 
       it 'registers the files with digests' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        md_rec1 = get_metadata_record(file_path, md_dir)
-        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
-        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect_digests(file_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a',
+                                  md5: '9f753c302ffa359ddb9a93fe979d6de1')
         expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
-        md_rec2 = get_metadata_record(file_path2, md_dir)
-        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
-        expect(md_rec2.checksums['md5']).to eq 'ce6320a83ead310ae30d43ae0f338bcc'
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7',
+                                  md5: 'ce6320a83ead310ae30d43ae0f338bcc')
 
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register multiple files with multiple checks from combined manifest' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "sha1:\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "sha1:\n" +
                    "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n" +
                    "md5:\n" +
@@ -295,21 +285,17 @@ describe 'register', :type => :aruba do
 
       it 'registers the files with digests' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        md_rec1 = get_metadata_record(file_path, md_dir)
-        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
-        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect_digests(file_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a',
+                                  md5: '9f753c302ffa359ddb9a93fe979d6de1')
         expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
-        md_rec2 = get_metadata_record(file_path2, md_dir)
-        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
-        expect(md_rec2.checksums).not_to include('md5')
-
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register from manifest without specifying algorithm' do
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest.txt',
-          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}") }
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}") }
 
       before do
         run_command_and_stop("longleaf register -c #{config_path} -m #{manifest_path}", fail_on_error: false)
@@ -323,9 +309,8 @@ describe 'register', :type => :aruba do
     end
 
     context 'register files from piped checksum manifest' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
 
       before do
@@ -336,19 +321,16 @@ describe 'register', :type => :aruba do
 
       it 'registers the files with digest' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        md_rec1 = get_metadata_record(file_path, md_dir)
-        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
+        expect_digests(file_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a')
         expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
-        md_rec2 = get_metadata_record(file_path2, md_dir)
-        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register files from piped combined manifest' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "sha1:\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "sha1:\n" +
                    "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n" +
                    "md5:\n" +
@@ -363,21 +345,17 @@ describe 'register', :type => :aruba do
 
       it 'registers the files with digest' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
-        md_rec1 = get_metadata_record(file_path, md_dir)
-        expect(md_rec1.checksums['sha1']).to eq 'e8241901910dac399e9fcd5fb5661e6923a0ce0a'
-        expect(md_rec1.checksums['md5']).to eq '9f753c302ffa359ddb9a93fe979d6de1'
+        expect_digests(file_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a',
+                                  md5: '9f753c302ffa359ddb9a93fe979d6de1')
         expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
-        md_rec2 = get_metadata_record(file_path2, md_dir)
-        expect(md_rec2.checksums['sha1']).to eq '013d5696728f086b8d2424b14beebc2695f926f7'
-        expect(md_rec2.checksums).not_to include('md5')
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
         expect(last_command_started).to have_exit_status(0)
       end
     end
 
     context 'register files from multiple stdin manifests' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}\n" +
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
 
       before do
@@ -394,9 +372,8 @@ describe 'register', :type => :aruba do
     end
 
     context 'register files from invalid manifest' do
-      let!(:file_path2) { create_test_file(dir: path_dir, name: 'another_file', content: 'more content') }
-      let!(:manifest_path) { create_test_file(dir: path_dir, name: 'manifest1.txt',
-          content: "what is\n" +
+      let!(:manifest_path) { create_manifest_file(
+                   "what is\n" +
                    "even happening\n" +
                    "here") }
 
@@ -411,10 +388,21 @@ describe 'register', :type => :aruba do
       end
     end
 
-    # test from stdin sha1:-
-    # test from stdin -
-    # test failure from invalid manifest format
-    # test failure from multiple stdin
+    context 'register files manifest param listing algorithm with combined manifest' do
+      let!(:manifest_path) { create_manifest_file(
+                   "sha1:\n" +
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a   #{file_path}"
+                   ) }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m sha1:#{manifest_path}", fail_on_error: false)
+      end
+
+      it 'returns error' do
+        expect(last_command_started).to have_output(/FAILURE: Invalid manifest entry: sha1:/)
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
   end
 
   def get_metadata_record_path(file_path, md_dir)
@@ -433,5 +421,24 @@ describe 'register', :type => :aruba do
     metadata_path = get_metadata_record_path(file_path, md_dir)
     md_rec = Longleaf::MetadataDeserializer.deserialize(file_path: metadata_path)
     md_rec.checksums[alg]
+  end
+
+  def expect_digests(file_path, md5: nil, sha1: nil)
+    md_rec = get_metadata_record(file_path, md_dir)
+    if md5.nil?
+      expect(md_rec.checksums).not_to include('md5')
+    else
+      expect(md_rec.checksums['md5']).to eq md5
+    end
+    if sha1.nil?
+      expect(md_rec.checksums).not_to include('sha1')
+    else
+      expect(md_rec.checksums['sha1']).to eq sha1
+    end
+  end
+
+  def create_manifest_file(body)
+    @m_index = @m_index.nil? ? 0 : @m_index + 1
+    create_test_file(dir: path_dir, name: "manifest#{@m_index}.txt", content: body)
   end
 end

--- a/spec/longleaf/events/register_event_spec.rb
+++ b/spec/longleaf/events/register_event_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'longleaf/candidates/single_digest_provider'
 require 'longleaf/models/file_record'
 require 'longleaf/events/register_event'
 require 'longleaf/services/application_config_deserializer'
@@ -152,8 +153,8 @@ describe Longleaf::RegisterEvent do
       it 'persists metadata with checksums' do
         event = Longleaf::RegisterEvent.new(file_rec: file_rec,
             app_manager: app_config,
-            checksums: { 'md5' => 'digestvalue',
-              'sha1' => 'shadigest' } )
+            digest_provider: Longleaf::SingleDigestProvider.new({ 'md5' => 'digestvalue',
+              'sha1' => 'shadigest' }) )
         status = event.perform
         expect(status).to eq 0
 


### PR DESCRIPTION
Resolves LEF-79

* Adds support for registering files from one or more checksum manifests, either from files or stdin
* Refactors the way digests are provided during registration into its own interface

Example with multiple manifests:
```
longleaf register -m md5:/path/to/manifest_md5.txt sha1:/path/to/manifest_sha1.txt -c /path_to/config.yml
```

Where manifest_sha1.txt could look like:
```
b8fd0a3c20bd8042791eb10eb723e53aa0b1f931   /path/to/storage/test.txt
```

Example combined manifest from stdin:
```
bundle exec exe/longleaf register -m @- -c /path/to/config.yml < /path/to/manifest.txt
```

Where manifest could look like:
```
sha1:
b8fd0a3c20bd8042791eb10eb723e53aa0b1f931   /path/to/storage/test.txt
md5:
77e9c13c3e3e1d72a868e4058fbea4c6   /path/to/storage/test.txt
```