### PR TITLE
LEF-85 - Allow deregisteration command to take a list of files

### DIFF
--- a/lib/longleaf/cli.rb
+++ b/lib/longleaf/cli.rb
@@ -71,6 +71,16 @@ module Longleaf
               :required => false,
               :desc => 'Name or comma separated names of storage locations to perform this operation over.' })
 
+    add_shared_option(
+        :from_list, :registered_selection, {
+              :aliases => "-l",
+              :required => false,
+              :desc => %q{Provide a list of files to perform this operation on. The list must be new line separated, one file per line.
+                To provide a list from a file:
+                '-l /path/to/file_list.txt'
+                To provide a list from STDIN:
+                '-l @-'}})
+
     # Commands
     map %w[--version] => :__print_version
     desc "--version", "Prints the Longleaf version number."
@@ -131,6 +141,7 @@ module Longleaf
 
     desc "deregister", "Deregister files with Longleaf"
     shared_options_group(:file_selection)
+    shared_options_group(:registered_selection)
     method_option(:force,
         :type => :boolean,
         :default => false,
@@ -150,6 +161,7 @@ module Longleaf
 
     desc "preserve", "Perform preservation services on files with Longleaf"
     shared_options_group(:file_selection)
+    shared_options_group(:registered_selection)
     method_option(:force,
         :type => :boolean,
         :default => false,
@@ -180,6 +192,7 @@ module Longleaf
 
     desc "validate_metadata", "Validate metadata files."
     shared_options_group(:file_selection)
+    shared_options_group(:registered_selection)
     shared_options_group(:common)
     # File metadata validation command
     def validate_metadata

--- a/spec/features/deregister_command_spec.rb
+++ b/spec/features/deregister_command_spec.rb
@@ -48,7 +48,6 @@ describe 'deregister', :type => :aruba do
       end
 
       it 'rejects file which does not exist' do
-        puts last_command_started.stderr
         expect(last_command_started).to have_output(
           /FAILURE deregister: File .* does not exist./)
         expect(last_command_started).to have_exit_status(1)

--- a/spec/features/deregister_command_spec.rb
+++ b/spec/features/deregister_command_spec.rb
@@ -48,9 +48,27 @@ describe 'deregister', :type => :aruba do
       end
 
       it 'rejects file which does not exist' do
+        puts last_command_started.stderr
         expect(last_command_started).to have_output(
           /FAILURE deregister: File .* does not exist./)
         expect(last_command_started).to have_exit_status(1)
+      end
+    end
+    
+    context 'file registered but does not exist' do
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f #{file_path}", fail_on_error: false)
+        
+        File.delete(file_path)
+
+        run_command_and_stop("longleaf deregister -c #{config_path} -f '#{file_path}'", fail_on_error: false)
+      end
+
+      it 'deregisters the file' do
+        expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
+        expect(file_deregistered?(file_path, md_dir)).to be true
+        expect(last_command_started).to have_exit_status(0)
+        expect(File).not_to exist(file_path)
       end
     end
     

--- a/spec/features/deregister_command_spec.rb
+++ b/spec/features/deregister_command_spec.rb
@@ -53,6 +53,44 @@ describe 'deregister', :type => :aruba do
         expect(last_command_started).to have_exit_status(1)
       end
     end
+    
+    context 'deregister from non-existent list' do
+      let!(:from_list_file) { File.join(path_dir, "path", "doesnt", "exist.txt") }
+      
+      before do
+        run_command_and_stop("longleaf deregister -c #{config_path} -l '#{from_list_file}'", fail_on_error: false)
+      end
+      
+      it 'rejects list which does not exist' do
+        expect(last_command_started).to have_output(
+          /FAILURE: Specified list file does not exist: #{from_list_file}/)
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+    
+    context 'from list parameter empty' do
+      before do
+        run_command_and_stop("longleaf deregister -c #{config_path} -l ''", fail_on_error: false)
+      end
+      
+      it 'rejects value' do
+        expect(last_command_started).to have_output(
+          /FAILURE: List parameter must not be empty/)
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+    
+    context 'providing -l and -f' do
+      before do
+        run_command_and_stop("longleaf deregister -c #{config_path} -f '#{file_path}' -l '#{file_path}'", fail_on_error: false)
+      end
+      
+      it 'rejects parameters' do
+        expect(last_command_started).to have_output(
+          /FAILURE: Only one of the following selection options may be provided: -l, -f, -s/)
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
 
     context 'file not in a registered storage location' do
       before do
@@ -152,12 +190,122 @@ describe 'deregister', :type => :aruba do
             run_command_and_stop("longleaf deregister -c #{config_path} -f '#{file_path},#{file_path2}'", fail_on_error: false)
           end
 
-          it 'registers both files' do
+          it 'deregisters both files' do
             expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
             expect(file_deregistered?(file_path, md_dir)).to be true
             expect(last_command_started).to have_output(/SUCCESS deregister #{file_path2}/)
             expect(file_deregistered?(file_path2, md_dir)).to be true
             expect(last_command_started).to have_exit_status(0)
+          end
+        end
+        
+        context 'deregister multiple files from file list' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "#{file_path}\n" +
+                       "#{file_path2}") }
+          
+          before do
+            run_command_and_stop("longleaf register -c #{config_path} -f #{file_path2}", fail_on_error: false)
+
+            run_command_and_stop("longleaf deregister -c #{config_path} -l '#{from_list_file}'", fail_on_error: false)
+          end
+          
+          it 'deregisters both files' do
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
+            expect(file_deregistered?(file_path, md_dir)).to be true
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path2}/)
+            expect(file_deregistered?(file_path2, md_dir)).to be true
+            expect(last_command_started).to have_exit_status(0)
+          end
+        end
+        
+        context 'deregister single file from STDIN list' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "#{file_path}") }
+          
+          before do
+            run_command_and_stop("longleaf register -c #{config_path} -f #{file_path2}", fail_on_error: false)
+
+            run_command("longleaf deregister -c #{config_path} -l @-", fail_on_error: false)
+            pipe_in_file(from_list_file)
+            close_input
+          end
+          
+          it 'deregisters one file' do
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
+            expect(file_deregistered?(file_path, md_dir)).to be true
+            expect(file_deregistered?(file_path2, md_dir)).to be false
+            expect(last_command_started).to have_exit_status(0)
+          end
+        end
+        
+        context 'deregister multiple files from STDIN list' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "#{file_path}\n" +
+                       "#{file_path2}") }
+          
+          before do
+            run_command_and_stop("longleaf register -c #{config_path} -f #{file_path2}", fail_on_error: false)
+
+            run_command("longleaf deregister -c #{config_path} -l @-", fail_on_error: false)
+            pipe_in_file(from_list_file)
+            close_input
+          end
+          
+          it 'deregisters both files' do
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
+            expect(file_deregistered?(file_path, md_dir)).to be true
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path2}/)
+            expect(file_deregistered?(file_path2, md_dir)).to be true
+            expect(last_command_started).to have_exit_status(0)
+          end
+        end
+        
+        context 'deregister multiple files from file list invalid format' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "#{file_path} #{file_path2}") }
+          
+          before do
+            run_command_and_stop("longleaf register -c #{config_path} -f #{file_path2}", fail_on_error: false)
+
+            run_command_and_stop("longleaf deregister -c #{config_path} -l '#{from_list_file}'", fail_on_error: false)
+          end
+          
+          it 'fails to deregister' do
+            expect(last_command_started).to have_output(
+                /FAILURE deregister: File #{file_path} #{file_path2} does not exist./)
+            expect(file_deregistered?(file_path, md_dir)).to be false
+            expect(file_deregistered?(file_path2, md_dir)).to be false
+          end
+        end
+        
+        context 'deregister file from file list with trailing newline' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "#{file_path}\n") }
+          
+          before do
+            run_command_and_stop("longleaf deregister -c #{config_path} -l '#{from_list_file}'", fail_on_error: false)
+          end
+          
+          it 'deregisters file' do
+            expect(last_command_started).to have_output(/SUCCESS deregister #{file_path}/)
+            expect(file_deregistered?(file_path, md_dir)).to be true
+            expect(last_command_started).to have_exit_status(0)
+          end
+        end
+        
+        context 'deregister with empty list file' do
+          let!(:from_list_file) { create_test_file(dir: path_dir, name: "file_list.txt", content:
+                       "") }
+          
+          before do
+            run_command_and_stop("longleaf deregister -c #{config_path} -l '#{from_list_file}'", fail_on_error: false)
+          end
+          
+          it 'deregisters both files' do
+            expect(last_command_started).to have_output(/File list is empty, must provide one or more files for this operation/)
+            expect(file_deregistered?(file_path, md_dir)).to be false
+            expect(last_command_started).to have_exit_status(1)
           end
         end
       end

--- a/spec/features/preserve_command_spec.rb
+++ b/spec/features/preserve_command_spec.rb
@@ -57,7 +57,7 @@ describe 'preserve', :type => :aruba do
       end
 
       it 'exits with failure' do
-        expect(last_command_started).to have_output(/Must provide either file paths or storage locations/)
+        expect(last_command_started).to have_output(/FAILURE: Must provide one of the following file selection options: -l, -f, or -s/)
         expect(last_command_started).to have_exit_status(1)
       end
     end
@@ -68,7 +68,7 @@ describe 'preserve', :type => :aruba do
       end
 
       it 'exits with failure' do
-        expect(last_command_started).to have_output(/Cannot provide both file paths and storage locations/)
+        expect(last_command_started).to have_output(/FAILURE: Only one of the following selection options may be provided: -l, -f, -s/)
         expect(last_command_started).to have_exit_status(1)
       end
     end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/LEF-85
* Deregistration command can receive a list of files to operate on, either from a file or from STDIN.
* Also allows for preserve and validate_metadata commands to take lists of files.