### PR TITLE
BXC-2855 - Remove md5 parameter from s3 upload_file

### DIFF
--- a/lib/longleaf/logging/redirecting_logger.rb
+++ b/lib/longleaf/logging/redirecting_logger.rb
@@ -65,6 +65,10 @@ module Longleaf
       def unknown(progname = nil, &block)
         @stderr_log.unknown(progname, &block)
       end
+      
+      def <<(msg)
+        @stderr_log << msg
+      end
 
       # Logs a success message to STDOUT, as well as STDERR at info level.
       #

--- a/lib/longleaf/models/s3_storage_location.rb
+++ b/lib/longleaf/models/s3_storage_location.rb
@@ -40,6 +40,7 @@ module Longleaf
         @client_options = Hash[custom_options.map { |(k,v)| [k.to_sym,v] } ]
       end
       @client_options[:logger] = logger
+      @client_options[:log_level] = :debug if @client_options[:log_level].nil?
       
       # If no region directly configured, use region from path
       if !@client_options.key?(:region)

--- a/lib/longleaf/models/s3_storage_location.rb
+++ b/lib/longleaf/models/s3_storage_location.rb
@@ -12,6 +12,7 @@ module Longleaf
   # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#constructor_details
 
   class S3StorageLocation < StorageLocation
+    include Longleaf::Logging
 
     IS_URI_REGEX = /\A#{URI::regexp}\z/
 
@@ -38,6 +39,8 @@ module Longleaf
         # Clone options and convert keys to symbols
         @client_options = Hash[custom_options.map { |(k,v)| [k.to_sym,v] } ]
       end
+      @client_options[:logger] = logger
+      
       # If no region directly configured, use region from path
       if !@client_options.key?(:region)
         region = S3UriHelper.extract_region(@path)

--- a/spec/longleaf/preservation_services/s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/s3_replication_service_spec.rb
@@ -142,33 +142,6 @@ describe Longleaf::S3ReplicationService do
         end
       end
 
-      context 'with md5' do
-        before do
-          md_rec.checksums['MD5'] = '9a0364b9e99bb480dd25e1f0284c8555'
-        end
-
-        it 'replicates file to s3 destination' do
-          service.perform(file_rec, PRESERVE_EVENT)
-
-          s3_client = dest1.s3_client
-          expect(s3_client.api_requests.size).to eq(2)
-          expect(s3_client.api_requests.last[:params]).to include(
-                  :bucket => "example",
-                  :key => 'path/test_file.txt',
-                  :content_md5 => 'mgNkuembtIDdJeHwKEyFVQ=='
-                )
-        end
-      end
-
-      context 'with invalid md5' do
-        before do
-          md_rec.checksums['MD5'] = '9a0364b9e99bohnodd25e1f0284c8555'
-          dest1.s3_client.stub_responses(:put_object, 'BadDigest')
-        end
-
-        it { expect { service.perform(file_rec, PRESERVE_EVENT) }.to raise_error(Longleaf::ChecksumMismatchError) }
-      end
-
       context 'with transfer error' do
         before do
           dest1.s3_client.stub_responses(:put_object, 'NoSuchUpload')


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2855
By default, the S3 client already calculates and submits md5s with both single and multipart uploads, so we do not need to submit our own MD5s with the requests. This resolves the problem with multipart uploads expecting md5s to be for individual parts rather than the whole file.
Also adds << method for logger, which is needed if you want to configure the client to wiretrace http requests