### PR TITLE
LEF-88 - Allow separate logical and physical paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
   test_with_ruby_latest:
     docker:
-      - image: circleci/ruby:latest
+      - image: circleci/ruby:2.7
         environment:
           BUNDLER_VERSION: 2.1.4
 

--- a/lib/longleaf/candidates/file_selector.rb
+++ b/lib/longleaf/candidates/file_selector.rb
@@ -85,11 +85,7 @@ module Longleaf
         @app_config.location_manager.verify_path_in_location(path)
         physical_path = @physical_provider.get_physical_path(path)
         separate_logical = physical_path != path
-        # if using separate logical and physical paths, only the physical path should exist in the storage location
         if separate_logical
-          if File.exist?(path)
-            raise InvalidStoragePathError.new("Logical path '#{path}' exists for physical file '#{physical_path}'")
-          end
           @app_config.location_manager.verify_path_in_location(physical_path)
         end
 

--- a/lib/longleaf/candidates/file_selector.rb
+++ b/lib/longleaf/candidates/file_selector.rb
@@ -1,4 +1,5 @@
 require 'longleaf/logging'
+require 'longleaf/candidates/physical_path_provider'
 
 module Longleaf
   # Selects and allows for iteration over files which match a provided set of selection criteria
@@ -10,7 +11,8 @@ module Longleaf
     attr_reader :specificity
 
     # May only provide either file_paths or storage_locations
-    def initialize(file_paths: nil, storage_locations: nil, physical_provider: nil, app_config:)
+    def initialize(file_paths: nil, storage_locations: nil, physical_provider: Longleaf::PhysicalPathProvider.new,
+           app_config:)
       if nil_or_empty?(file_paths) && nil_or_empty?(storage_locations)
         raise ArgumentError.new("Must provide either file paths or storage locations")
       end

--- a/lib/longleaf/candidates/manifest_digest_provider.rb
+++ b/lib/longleaf/candidates/manifest_digest_provider.rb
@@ -1,7 +1,7 @@
 module Longleaf
   # Provides digests for files from a manifest
   class ManifestDigestProvider
-    # @param hash which maps file paths to hashs of digests
+    # @param digests_mapping hash which maps file paths to hashs of digests
     def initialize(digests_mapping)
       @digests_mapping = digests_mapping
     end

--- a/lib/longleaf/candidates/physical_path_provider.rb
+++ b/lib/longleaf/candidates/physical_path_provider.rb
@@ -1,0 +1,17 @@
+module Longleaf
+  # Provides physical paths for logical paths from a mapping
+  class PhysicalPathProvider
+    # @param phys_mapping hash with logical paths as keys, physical paths as values
+    def initialize(phys_mapping = Hash.new)
+      @phys_mapping = phys_mapping
+    end
+
+    # @param logical_path [String] logical path of file
+    # @return physical path of the file
+    def get_physical_path(logical_path)
+      # return the logical path itself if no physical path is mapped
+      return logical_path unless @phys_mapping.key?(logical_path)
+      @phys_mapping[logical_path]
+    end
+  end
+end

--- a/lib/longleaf/cli.rb
+++ b/lib/longleaf/cli.rb
@@ -65,12 +65,12 @@ module Longleaf
               :aliases => "-f",
               :required => false,
               :desc => 'File or files to perform this operation on. If multiple files are provided, they must be comma separated.' })
+
     add_shared_option(
-        :location, :file_selection, {
+        :location, :registered_selection, {
               :aliases => "-s",
               :required => false,
               :desc => 'Name or comma separated names of storage locations to perform this operation over.' })
-
     add_shared_option(
         :from_list, :registered_selection, {
               :aliases => "-l",
@@ -115,7 +115,21 @@ module Longleaf
           ...
           md5:
           <digest> <path>
-          ...})
+          ...
+          
+          To provide separate logical and physical paths, add a physical path column:
+          '-m sha1:@-'
+          Where the content in STDIN adheres to the format:
+          <digest> <logical path> <physical path>
+          ...
+        })
+    method_option(:physical_path,
+        :aliases => "-p",
+        :required => false,
+        :desc => %q{Comma separated list of physical paths of files to register. Only needed
+          if the physical and logical paths of the files differ, otherwise they will be assumed to be the same.
+          Only applicable when used with the -f option, and only for individual files, not directories.
+          Must be provided in the same order as the logical paths.})
     method_option(:force,
         :type => :boolean,
         :default => false,
@@ -132,11 +146,12 @@ module Longleaf
 
       app_config_manager = load_application_config(options)
 
-      file_selector, digest_provider = SelectionOptionsParser.parse_registration_selection_options(
-          options, app_config_manager)
+      file_selector, digest_provider, physical_provider = SelectionOptionsParser
+          .parse_registration_selection_options(options, app_config_manager)
 
       command = RegisterCommand.new(app_config_manager)
-      exit command.execute(file_selector: file_selector, force: options[:force], digest_provider: digest_provider)
+      exit command.execute(file_selector: file_selector, force: options[:force], digest_provider: digest_provider,
+           physical_provider: physical_provider)
     end
 
     desc "deregister", "Deregister files with Longleaf"

--- a/lib/longleaf/commands/register_command.rb
+++ b/lib/longleaf/commands/register_command.rb
@@ -16,9 +16,10 @@ module Longleaf
     # Execute the register command on the given parameters
     # @param file_selector [FileSelector] selector for files to register
     # @param force [Boolean] force flag
-    # @param digest_provider [DigestProvider] object which provides digests for files being registered
+    # @param digest_provider [ManifestDigestProvider] object which provides digests for files being registered
+    # @param physical_provider [PhysicalPathProvider] object which provides physical paths for files being registered
     # @return [Integer] status code
-    def execute(file_selector:, force: false, digest_provider: nil)
+    def execute(file_selector:, force: false, digest_provider: nil, physical_provider: nil)
       start_time = Time.now
       logger.info('Performing register command')
       begin
@@ -29,7 +30,8 @@ module Longleaf
 
           storage_location = @app_manager.location_manager.get_location_by_path(f_path)
 
-          file_rec = FileRecord.new(f_path, storage_location)
+          phys_path = physical_provider.get_physical_path(f_path)
+          file_rec = FileRecord.new(f_path, storage_location, nil, phys_path)
 
           register_event = RegisterEvent.new(file_rec: file_rec, force: force, app_manager: @app_manager,
               digest_provider: digest_provider)

--- a/lib/longleaf/events/preserve_event.rb
+++ b/lib/longleaf/events/preserve_event.rb
@@ -27,12 +27,13 @@ module Longleaf
       service_manager = @app_manager.service_manager
       md_rec = @file_rec.metadata_record
       f_path = @file_rec.path
+      phys_path = @file_rec.physical_path
 
-      logger.info("Performing preserve event on #{@file_rec.path}")
+      logger.info("Performing preserve event on #{f_path}")
 
       needs_persist = false
       begin
-        if !File.exist?(f_path)
+        if !File.exist?(phys_path)
           # Need to persist metadata to avoid repeating processing of this file too soon.
           needs_persist = true
           record_failure(EventNames::PRESERVE, f_path, "File is registered but missing.")

--- a/lib/longleaf/events/register_event.rb
+++ b/lib/longleaf/events/register_event.rb
@@ -70,10 +70,17 @@ module Longleaf
     private
     def populate_file_properties
       md_rec = @file_rec.metadata_record
+      physical_path = @file_rec.physical_path
 
       # Set file properties
-      md_rec.last_modified = File.mtime(@file_rec.path).utc.iso8601(3)
-      md_rec.file_size = File.size(@file_rec.path)
+      md_rec.last_modified = File.mtime(physical_path).utc.iso8601(3)
+      md_rec.file_size = File.size(physical_path)
+
+      if physical_path != @file_rec.path
+        md_rec.physical_path = physical_path
+      else
+        md_rec.physical_path = nil
+      end
     end
 
     # Copy a subset of properties from an existing metadata record to the new record

--- a/lib/longleaf/models/file_record.rb
+++ b/lib/longleaf/models/file_record.rb
@@ -3,17 +3,25 @@ module Longleaf
   class FileRecord
     attr_accessor :metadata_record
     attr_reader :storage_location
+    attr_reader :physical_path
     attr_reader :path
 
     # @param file_path [String] path to the file
     # @param storage_location [StorageLocation] storage location containing the file
-    def initialize(file_path, storage_location, metadata_record = nil)
+    # @param metadata_record [MetadataRecord] metadata record for this file object. Optional.
+    # @param physical_path [String] physical path where the file is located. Defaults to the file_path.
+    def initialize(file_path, storage_location, metadata_record = nil, physical_path = nil)
       raise ArgumentError.new("FileRecord requires a path") if file_path.nil?
       raise ArgumentError.new("FileRecord requires a storage_location") if storage_location.nil?
 
       @path = file_path
       @storage_location = storage_location
       @metadata_record = metadata_record
+      if physical_path.nil?
+        @physical_path = file_path
+      else
+        @physical_path = physical_path
+      end
     end
 
     # @return [String] path for the metadata file for this file

--- a/lib/longleaf/models/file_record.rb
+++ b/lib/longleaf/models/file_record.rb
@@ -3,7 +3,6 @@ module Longleaf
   class FileRecord
     attr_accessor :metadata_record
     attr_reader :storage_location
-    attr_reader :physical_path
     attr_reader :path
 
     # @param file_path [String] path to the file
@@ -17,17 +16,24 @@ module Longleaf
       @path = file_path
       @storage_location = storage_location
       @metadata_record = metadata_record
-      if physical_path.nil?
-        @physical_path = file_path
-      else
-        @physical_path = physical_path
-      end
+      @physical_path = physical_path
     end
 
     # @return [String] path for the metadata file for this file
     def metadata_path
       @metadata_path = @storage_location.get_metadata_path_for(path) if @metadata_path.nil?
       @metadata_path
+    end
+    
+    def physical_path
+      if @physical_path.nil?
+        if @metadata_record.nil? || @metadata_record.physical_path.nil?
+          @physical_path = @path
+        else
+          @physical_path = @metadata_record.physical_path
+        end
+      end
+      @physical_path
     end
 
     def metadata_present?

--- a/lib/longleaf/models/md_fields.rb
+++ b/lib/longleaf/models/md_fields.rb
@@ -9,6 +9,7 @@ module Longleaf
 
     LAST_MODIFIED = 'last-modified'
     FILE_SIZE = 'size'
+    PHYSICAL_PATH = 'physical-path'
 
     CHECKSUMS = 'checksums'
 

--- a/lib/longleaf/models/metadata_record.rb
+++ b/lib/longleaf/models/metadata_record.rb
@@ -10,6 +10,7 @@ module Longleaf
     attr_reader :checksums
     attr_reader :properties
     attr_accessor :file_size, :last_modified
+    attr_accessor :physical_path
 
     # @param properties [Hash] initial data properties for this record
     # @param services [Hash] initial service property tree
@@ -18,8 +19,9 @@ module Longleaf
     # @param checksums [Hash] hash of checksum values
     # @param file_size [Integer] size of file in bytes
     # @param last_modified [String] iso8601 representation of the last modified date of file
+    # @param physical_path [String] physical path where the file is located
     def initialize(properties: nil, services: nil, deregistered: nil, registered: nil, checksums: nil,
-          file_size: nil, last_modified: nil)
+          file_size: nil, last_modified: nil, physical_path: nil)
       @properties = properties || Hash.new
       @registered = registered
       @deregistered = deregistered
@@ -28,6 +30,7 @@ module Longleaf
       @services = services || Hash.new
       @file_size = file_size
       @last_modified = last_modified
+      @physical_path = physical_path
     end
 
     # @return [Boolean] true if the record is deregistered

--- a/lib/longleaf/models/s3_storage_location.rb
+++ b/lib/longleaf/models/s3_storage_location.rb
@@ -1,6 +1,7 @@
 require 'longleaf/models/storage_location'
 require 'longleaf/models/storage_types'
 require 'longleaf/helpers/s3_uri_helper'
+require 'longleaf/logging'
 require 'uri'
 require 'aws-sdk-s3'
 

--- a/lib/longleaf/preservation_services/file_check_service.rb
+++ b/lib/longleaf/preservation_services/file_check_service.rb
@@ -23,22 +23,23 @@ module Longleaf
     # @raise [PreservationServiceError] if the file system information does not match the stored details
     def perform(file_rec, event)
       file_path = file_rec.path
+      phys_path = file_rec.physical_path
       md_rec = file_rec.metadata_record
 
       logger.debug("Performing file information check of #{file_path}")
 
-      if !File.exist?(file_path)
-        raise PreservationServiceError.new("File does not exist: #{file_path}")
+      if !File.exist?(phys_path)
+        raise PreservationServiceError.new("File does not exist: #{phys_path}")
       end
 
-      file_size = File.size(file_rec.path)
+      file_size = File.size(phys_path)
       if file_size != md_rec.file_size
-        raise PreservationServiceError.new("File size for #{file_path} does not match the expected value: registered = #{md_rec.file_size} bytes, actual = #{file_size} bytes")
+        raise PreservationServiceError.new("File size for #{phys_path} does not match the expected value: registered = #{md_rec.file_size} bytes, actual = #{file_size} bytes")
       end
 
-      last_modified = File.mtime(file_rec.path).utc.iso8601(3)
+      last_modified = File.mtime(phys_path).utc.iso8601(3)
       if last_modified != md_rec.last_modified
-        raise PreservationServiceError.new("Last modified timestamp for #{file_path} does not match the expected value: registered = #{md_rec.last_modified}, actual = #{last_modified}")
+        raise PreservationServiceError.new("Last modified timestamp for #{phys_path} does not match the expected value: registered = #{md_rec.last_modified}, actual = #{last_modified}")
       end
     end
 

--- a/lib/longleaf/preservation_services/fixity_check_service.rb
+++ b/lib/longleaf/preservation_services/fixity_check_service.rb
@@ -63,6 +63,7 @@ module Longleaf
     # @raise [ChecksumMismatchError] if the checksum on record does not match the generated checksum
     def perform(file_rec, event)
       path = file_rec.path
+      phys_path = file_rec.physical_path
       md_rec = file_rec.metadata_record
 
       # Get the list of existing checksums for the file and normalize algorithm names
@@ -89,19 +90,19 @@ module Longleaf
         end
 
         digest = DigestHelper::start_digest(alg)
-        digest.file(path)
+        digest.file(phys_path)
         generated_digest = digest.hexdigest
 
         # Store the missing checksum if using the 'generate' behavior
         if existing_digest.nil? && @absent_digest_behavior == GENERATE_IF_ABSENT
           md_rec.checksums[alg] = generated_digest
-          logger.info("Generated and stored digest using algorithm '#{alg}' for file #{path}")
+          logger.info("Generated and stored digest using algorithm '#{alg}' for file #{phys_path}")
         else
           # Compare the new digest to the one on record
           if existing_digest == generated_digest
-            logger.info("Fixity check using algorithm '#{alg}' succeeded for file #{path}")
+            logger.info("Fixity check using algorithm '#{alg}' succeeded for file #{phys_path}")
           else
-            raise ChecksumMismatchError.new("Fixity check using algorithm '#{alg}' failed for file #{path}: expected '#{existing_digest}', calculated '#{generated_digest}.'")
+            raise ChecksumMismatchError.new("Fixity check using algorithm '#{alg}' failed for file #{phys_path}: expected '#{existing_digest}', calculated '#{generated_digest}.'")
           end
         end
       end

--- a/lib/longleaf/preservation_services/s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/s3_replication_service.rb
@@ -90,7 +90,7 @@ module Longleaf
         rel_to_bucket = destination.relative_to_bucket_path(rel_path)
         file_obj = destination.s3_bucket.object(rel_to_bucket)
         begin
-          file_obj.upload_file(file_rec.path)
+          file_obj.upload_file(file_rec.physical_path)
         rescue Aws::S3::Errors::BadDigest => e
           raise ChecksumMismatchError.new("Transfer to bucket '#{destination.s3_bucket.name}' failed, " \
               + "MD5 provided did not match the received content for #{file_rec.path}")

--- a/lib/longleaf/services/metadata_deserializer.rb
+++ b/lib/longleaf/services/metadata_deserializer.rb
@@ -32,6 +32,7 @@ module Longleaf
       checksums = data.delete(MDFields::CHECKSUMS)
       file_size = data.delete(MDFields::FILE_SIZE)
       last_modified = data.delete(MDFields::LAST_MODIFIED)
+      physical_path = data.delete(MDFields::PHYSICAL_PATH)
 
       services = md[MDF::SERVICES]
       service_records = Hash.new
@@ -57,7 +58,8 @@ module Longleaf
                          deregistered: deregistered,
                          checksums: checksums,
                          file_size: file_size,
-                         last_modified: last_modified)
+                         last_modified: last_modified,
+                         physical_path: physical_path)
     end
 
     # Load configuration a yaml encoded configuration file

--- a/lib/longleaf/services/metadata_serializer.rb
+++ b/lib/longleaf/services/metadata_serializer.rb
@@ -52,6 +52,7 @@ module Longleaf
       data[MDF::CHECKSUMS] = metadata.checksums unless metadata.checksums && metadata.checksums.empty?
       data[MDF::FILE_SIZE] = metadata.file_size unless metadata.file_size.nil?
       data[MDF::LAST_MODIFIED] = metadata.last_modified if metadata.last_modified
+      data[MDF::PHYSICAL_PATH] = metadata.physical_path if metadata.physical_path
 
       props[MDF::DATA] = data
 

--- a/lib/longleaf/specs/metadata_builder.rb
+++ b/lib/longleaf/specs/metadata_builder.rb
@@ -29,6 +29,11 @@ module Longleaf
       @checksums[alg] = value
       self
     end
+    
+    def with_physical_path(phys_path)
+      @physical_path = phys_path
+      self
+    end
 
     def with_service(name, timestamp: ServiceDateHelper::formatted_timestamp, run_needed: false, properties: nil,
           failure_timestamp: nil)
@@ -56,7 +61,8 @@ module Longleaf
           registered: @registered,
           checksums: @checksums,
           file_size: @file_size,
-          last_modified: @last_modified)
+          last_modified: @last_modified,
+          physical_path: @physical_path)
     end
 
     # Add the generated metadata record to the given file record

--- a/spec/factories/file_records.rb
+++ b/spec/factories/file_records.rb
@@ -5,7 +5,8 @@ FactoryBot.define do
     storage_location { build(:storage_location) }
     file_path { '/file/path/file' }
     metadata_record { nil }
+    physical_path { nil }
 
-    initialize_with { new(file_path, storage_location, metadata_record) }
+    initialize_with { new(file_path, storage_location, metadata_record, physical_path) }
   end
 end

--- a/spec/features/file_check_feature_spec.rb
+++ b/spec/features/file_check_feature_spec.rb
@@ -80,8 +80,6 @@ describe 'fixity check service', :type => :aruba do
       
       context 'with unchanged state' do
         before do
-          run_command_and_stop("longleaf register -c #{config_path} -f #{logical_path} -p #{file_path}", fail_on_error: false)
-
           run_command_and_stop("longleaf preserve -c #{config_path} -f #{logical_path}", fail_on_error: false)
         end
         

--- a/spec/features/preserve_command_spec.rb
+++ b/spec/features/preserve_command_spec.rb
@@ -162,6 +162,36 @@ describe 'preserve', :type => :aruba do
         end
       end
     end
+    
+    context 'specifying one file with separate physical location' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f #{logical_path} -p #{file_path}", fail_on_error: false)
+      end
+      
+      context 'provide physical path to preserve command' do
+        before do
+          run_command_and_stop("longleaf preserve -c #{config_path} -I #{lib_dir} -f #{file_path}", fail_on_error: false)
+        end
+
+        it 'Cannot locate file' do
+          expect(last_command_started).to have_output(/FAILURE preserve: File #{file_path} is not registered/)
+          expect(last_command_started).to have_exit_status(1)
+        end
+      end
+
+      context 'service has not run before' do
+        before do
+          run_command_and_stop("longleaf preserve -c #{config_path} -I #{lib_dir} -f #{logical_path}", fail_on_error: false)
+        end
+
+        it 'successfully verifies file' do
+          expect(last_command_started).to have_output(/SUCCESS preserve\[serv1\] #{logical_path}/)
+          expect(last_command_started).to have_exit_status(0)
+        end
+      end
+    end
   end
 
   context 'with failing service configured' do

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -235,7 +235,7 @@ describe 'register', :type => :aruba do
              fail_on_error: false)
       end
 
-      it 'registers files with physical paths' do
+      it 'rejects registration' do
         expect(last_command_started).to have_output(/FAILURE register: File #{physical_path} does not exist/)
         expect(metadata_created(logical_path, md_dir)).to be false
         expect(last_command_started).to have_exit_status(1)
@@ -251,7 +251,7 @@ describe 'register', :type => :aruba do
              fail_on_error: false)
       end
 
-      it 'registers files with physical paths' do
+      it 'rejects registration' do
         expect(last_command_started).to have_output(
             /FAILURE register: Path #{physical_path} is not from a known storage location/)
         expect(metadata_created(logical_path, md_dir)).to be false
@@ -265,10 +265,11 @@ describe 'register', :type => :aruba do
              fail_on_error: false)
       end
 
-      it 'rejects existing logical path' do
-        expect(last_command_started).to have_output(/FAILURE register: Logical path '#{file_path}' exists.*/)
-        expect(metadata_created(file_path, md_dir)).to be false
-        expect(last_command_started).to have_exit_status(1)
+      it 'register file with physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        expect(metadata_created(file_path, md_dir)).to be true
+        expect_physical_path(file_path, file_path2)
+        expect(last_command_started).to have_exit_status(0)
       end
     end
 

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -161,9 +161,9 @@ describe 'register', :type => :aruba do
       end
     end
 
-    context 'register multiple files by storage location' do
+    context 'register directory of files' do
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -s 'loc1' --log-level 'DEBUG'", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{path_dir}/'", fail_on_error: false)
       end
 
       it 'registers both files' do
@@ -175,16 +175,185 @@ describe 'register', :type => :aruba do
       end
     end
 
-    context 'register directory of files' do
+    context 'register file with separate physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{path_dir}/' --log_level DEBUG", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{logical_path}' -p '#{file_path}'",
+             fail_on_error: false)
       end
 
-      it 'registers both files' do
+      it 'registers file with physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect(metadata_created(logical_path, md_dir)).to be true
+        expect_physical_path(logical_path, file_path)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register file with same logical and physical path' do
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{file_path}' -p '#{file_path}'",
+             fail_on_error: false)
+      end
+
+      it 'registers file without physical path' do
         expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
         expect(metadata_created(file_path, md_dir)).to be true
-        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
-        expect(metadata_created(file_path2, md_dir)).to be true
+        expect_physical_path(file_path, nil)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register two files with separate physical paths' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:logical_path2) { File.join(path_dir, "logical2") }
+
+      before do
+        run_command_and_stop(%Q{longleaf register -c #{config_path} -f '#{logical_path},#{logical_path2}'
+             -p '#{file_path},#{file_path2}'},
+             fail_on_error: false)
+      end
+
+      it 'registers files with physical paths' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path2}/)
+        expect(metadata_created(logical_path, md_dir)).to be true
+        expect_physical_path(logical_path, file_path)
+        expect(metadata_created(logical_path2, md_dir)).to be true
+        expect_physical_path(logical_path2, file_path2)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register file with non-existent physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:physical_path) { File.join(path_dir, "physical") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{logical_path}' -p '#{physical_path}'",
+             fail_on_error: false)
+      end
+
+      it 'registers files with physical paths' do
+        expect(last_command_started).to have_output(/FAILURE register: File #{physical_path} does not exist/)
+        expect(metadata_created(logical_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register file with physical path not in storage location' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:physical_path) { create_test_file }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{logical_path}' -p '#{physical_path}'",
+             fail_on_error: false)
+      end
+
+      it 'registers files with physical paths' do
+        expect(last_command_started).to have_output(
+            /FAILURE register: Path #{physical_path} is not from a known storage location/)
+        expect(metadata_created(logical_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register existing logical path with physical path' do
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{file_path}' -p '#{file_path2}'",
+             fail_on_error: false)
+      end
+
+      it 'rejects existing logical path' do
+        expect(last_command_started).to have_output(/FAILURE register: Logical path '#{file_path}' exists.*/)
+        expect(metadata_created(file_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register two files with one physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:logical_path2) { File.join(path_dir, "logical2") }
+
+      before do
+        run_command_and_stop(%Q{longleaf register -c #{config_path} -f '#{logical_path},#{logical_path2}'
+             -p '#{file_path}'}, fail_on_error: false)
+      end
+
+      it 'rejects mismatched parameters' do
+        expect(last_command_started).to have_output(
+            /FAILURE: Invalid physical paths parameter, number of paths did not match.*/)
+        expect(metadata_created(logical_path, md_dir)).to be false
+        expect(metadata_created(logical_path2, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'register one file with too many physical paths' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:logical_path2) { File.join(path_dir, "logical2") }
+
+      before do
+        run_command_and_stop(%Q{longleaf register -c #{config_path} -f '#{logical_path}'
+             -p '#{file_path},#{file_path2}'}, fail_on_error: false)
+      end
+
+      it 'rejects mismatched parameters' do
+        expect(last_command_started).to have_output(
+            /FAILURE: Invalid physical paths parameter, number of paths did not match.*/)
+        expect(metadata_created(logical_path, md_dir)).to be false
+        expect(last_command_started).to have_exit_status(1)
+      end
+    end
+
+    context 'reregister file that has physical path with new physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{logical_path}' -p '#{file_path}'",
+             fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} --force -f '#{logical_path}' -p '#{file_path2}'",
+             fail_on_error: false)
+      end
+
+      it 'registers file with physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect_physical_path(logical_path, file_path2)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'reregister file that has physical path with no physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{logical_path}' -p '#{file_path}'",
+             fail_on_error: false)
+        FileUtils.touch(logical_path)
+        run_command_and_stop("longleaf register -c #{config_path} --force -f '#{logical_path}'",
+             fail_on_error: false)
+      end
+
+      it 'registers file with physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect_physical_path(logical_path, nil)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'reregister file that does not have a physical path with a physical path' do
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{file_path}'", fail_on_error: false)
+        File.delete(file_path)
+        run_command_and_stop(%Q{longleaf register -c #{config_path} --force -f '#{file_path}'
+              -p #{file_path2}},
+             fail_on_error: false)
+      end
+
+      it 'registers file with physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path}/)
+        expect_physical_path(file_path, file_path2)
         expect(last_command_started).to have_exit_status(0)
       end
     end
@@ -232,7 +401,7 @@ describe 'register', :type => :aruba do
                    "013d5696728f086b8d2424b14beebc2695f926f7   #{file_path2}\n") }
 
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}'", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}' --log_level DEBUG", fail_on_error: false)
       end
 
       it 'registers the files with digest' do
@@ -403,6 +572,67 @@ describe 'register', :type => :aruba do
         expect(last_command_started).to have_exit_status(1)
       end
     end
+
+    context 'register multiple from checksum manifest with physical paths' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:logical_path2) { File.join(path_dir, "logical2") }
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a  #{logical_path} #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7  #{logical_path2} #{file_path2}\n") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}'", fail_on_error: false)
+      end
+
+      it 'registers the files with digest and physical paths' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect_digests(logical_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a')
+        expect_physical_path(logical_path, file_path)
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path2}/)
+        expect_digests(logical_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
+        expect_physical_path(logical_path2, file_path2)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register multiple from checksum manifest, one with physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      let!(:manifest_path) { create_manifest_file(
+                   "e8241901910dac399e9fcd5fb5661e6923a0ce0a  #{logical_path} #{file_path}\n" +
+                   "013d5696728f086b8d2424b14beebc2695f926f7  #{file_path2}\n") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}'", fail_on_error: false)
+      end
+
+      it 'registers the files with digests and physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect_digests(logical_path, sha1: 'e8241901910dac399e9fcd5fb5661e6923a0ce0a')
+        expect_physical_path(logical_path, file_path)
+        expect(last_command_started).to have_output(/SUCCESS register #{file_path2}/)
+        expect_digests(file_path2, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
+        expect_physical_path(file_path2, nil)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
+
+    context 'register from checksum manifest with spaces in logical and physical path' do
+      let!(:logical_path) { File.join(path_dir, "logical space") }
+      let!(:physical_path) { create_test_file(dir: path_dir, name: 'spacey file', content: 'more content') }
+      let!(:manifest_path) { create_manifest_file(
+                   "013d5696728f086b8d2424b14beebc2695f926f7  '#{logical_path}' '#{physical_path}'\n") }
+
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -m 'sha1:#{manifest_path}'", fail_on_error: false)
+      end
+
+      it 'registers the files with digest and physical path' do
+        expect(last_command_started).to have_output(/SUCCESS register #{logical_path}/)
+        expect_digests(logical_path, sha1: '013d5696728f086b8d2424b14beebc2695f926f7')
+        expect_physical_path(logical_path, physical_path)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
   end
 
   def get_metadata_record_path(file_path, md_dir)
@@ -434,6 +664,15 @@ describe 'register', :type => :aruba do
       expect(md_rec.checksums).not_to include('sha1')
     else
       expect(md_rec.checksums['sha1']).to eq sha1
+    end
+  end
+
+  def expect_physical_path(logical_path, physical_path)
+    md_rec = get_metadata_record(logical_path, md_dir)
+    if physical_path.nil?
+      expect(md_rec.physical_path).to be_nil
+    else
+      expect(md_rec.physical_path).to eq physical_path
     end
   end
 

--- a/spec/features/validate_metadata_command_spec.rb
+++ b/spec/features/validate_metadata_command_spec.rb
@@ -81,6 +81,21 @@ describe 'validate_metadata', :type => :aruba do
         expect(last_command_started).to have_exit_status(0)
       end
     end
+    
+    context 'file with separate logical and physical paths' do
+      let!(:logical_path) { File.join(path_dir, "logical") }
+      
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f #{logical_path} -p '#{file_path}'", fail_on_error: false)
+        run_command_and_stop("longleaf validate_metadata -c #{config_path} -f '#{logical_path}' --log_level INFO", fail_on_error: false)
+      end
+
+      it 'passes validation without warnings' do
+        expect(last_command_started).to have_output(/SUCCESS: Metadata for file passed validation: #{logical_path}/)
+        expect(last_command_started).to have_output(/Metadata fixity check using algorithm 'sha1' succeeded for file .*/)
+        expect(last_command_started).to have_exit_status(0)
+      end
+    end
 
     context 'file with checksum mismatch' do
       before do

--- a/spec/longleaf/preservation_services/rsync_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/rsync_replication_service_spec.rb
@@ -81,8 +81,8 @@ describe Longleaf::RsyncReplicationService do
       let(:service_def) { make_service_def(['dest_loc'], options: '-W -vc --chmod "0440"') }
       let(:service) { RsyncService.new(service_def, app_manager) }
 
-      it "include all provided options plus -R" do
-        expect(service.options).to eq '-W -vc --chmod "0440" -R'
+      it "include all provided options" do
+        expect(service.options).to eq '-W -vc --chmod "0440"'
       end
     end
 
@@ -91,7 +91,7 @@ describe Longleaf::RsyncReplicationService do
       let(:service) { RsyncService.new(service_def, app_manager) }
 
       it "has default configuration options" do
-        expect(service.options).to eq '-a -R'
+        expect(service.options).to eq '-a'
         expect(service.command).to eq 'rsync'
         expect(service.collision_policy).to eq 'replace'
       end


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/LEF-88

* Allows register command to optionally take a physical path, which is distinct from the logical path
    * Physical path may be provided via `-p` for lists of files, or by providing it as the third field in a checksum manifest
    * The physical path must be within a valid storage location, but otherwise does not need to match the logical path.
* The logical path is used for locating metadata and determining replica paths
* Removes ability to register files by storage location
* Had to cap circleci at ruby 2.7 since it was trying to run 3.0.0, which is not currently supported