### PR TITLE
LEF-92 - Keep original metadata file until temp move is successful

### DIFF
--- a/lib/longleaf/services/metadata_serializer.rb
+++ b/lib/longleaf/services/metadata_serializer.rb
@@ -117,11 +117,15 @@ module Longleaf
             # Set permissions of new file to match old if it exists
             old_stat = File.stat(file_path)
             set_perms(temp_path, old_stat)
+
+            # Produce digest files for the temp file
+            digest_paths = write_digests(temp_path, content, digest_algs)
+            
             # Move the old file to a temp path in case it needs to be restored
             old_renamed = temp_path + ".old"
             File.rename(file_path, old_renamed)
-
-            digest_paths = write_digests(temp_path, content, digest_algs)
+            
+            # Move move the new file into place as the new main file
             File.rename(temp_path, file_path)
           rescue => e
             # Attempt to restore old file if it had already been moved


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/LEF-92

For atomic write of metadata files, move the original metadata file out of the way before moving the new file into place. Otherwise the rename operation can fail inbetween deleting the old file and renaming the new file