### PR TITLE
LEF-107 - Metadata file and index service_time out of sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
+    pg (1.4.6)
     rainbow (3.1.1)
     rake (12.3.3)
     rspec (3.11.0)
@@ -158,7 +158,7 @@ DEPENDENCIES
   longleaf!
   mysql
   mysql2 (>= 0.5.0)
-  pg (>= 1.0.0)
+  pg (= 1.4.6)
   rake (~> 12.0)
   rspec (~> 3.8)
   rspec-core (~> 3.8)
@@ -171,4 +171,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.18
+   2.2.34

--- a/lib/longleaf/events/preserve_event.rb
+++ b/lib/longleaf/events/preserve_event.rb
@@ -73,6 +73,9 @@ module Longleaf
         if needs_persist
           # persist the metadata
           @app_manager.md_manager.persist(@file_rec)
+        else
+          # Preserve event was called for an item that didn't need any services run, so index might be stale if in use
+          @app_manager.md_manager.index(@file_rec)
         end
       end
 

--- a/spec/longleaf/events/preserve_event_spec.rb
+++ b/spec/longleaf/events/preserve_event_spec.rb
@@ -151,7 +151,7 @@ describe Longleaf::PreserveEvent do
               allow(index_manager).to receive(:index)
             end
 
-            it 'makes no updates to file metadata record, but updates the index in case its stale' do
+            it 'makes no updates to file metadata record, but updates the index in case it is stale' do
               perform_and_verify_no_change(event, md_path)
               expect(index_manager).to have_received(:index).with(file_rec)
             end

--- a/spec/longleaf/events/preserve_event_spec.rb
+++ b/spec/longleaf/events/preserve_event_spec.rb
@@ -144,6 +144,18 @@ describe Longleaf::PreserveEvent do
           it 'makes no updates to file metadata record' do
             perform_and_verify_no_change(event, md_path)
           end
+
+          context 'with index enabled' do
+            let(:index_manager) { double(using_index?: true) }
+            before do
+              allow(index_manager).to receive(:index)
+            end
+
+            it 'makes no updates to file metadata record, but updates the index in case its stale' do
+              perform_and_verify_no_change(event, md_path)
+              expect(index_manager).to have_received(:index).with(file_rec)
+            end
+          end
         end
 
         context 'needs to run again' do


### PR DESCRIPTION
* Add indexing of file records if a preserve event for that record does not result in any services needing to be run, in case that indicates the index is stale. If no index is configured, this will result in no work. The reason for this change is for scenarios where the preserve event is interrupted after the metadata file is updated, but before the index finishes updating, which can cause the Candidate Iterator to perpetually return a file that doesn't have any services to run. So now if the candidate iterator returned a file that didn't end up needing any services run, the index entry for it will get updated.