### PR TITLE
BXC-5655 - Prevent infinite candidate loops for deleted files

### DIFF
--- a/lib/longleaf/candidates/service_candidate_index_iterator.rb
+++ b/lib/longleaf/candidates/service_candidate_index_iterator.rb
@@ -1,6 +1,7 @@
 require 'longleaf/events/event_names'
 require 'longleaf/errors'
 require 'longleaf/logging'
+require 'set'
 require 'time'
 
 module Longleaf
@@ -18,8 +19,11 @@ module Longleaf
       @index_manager = @app_config.index_manager
       @stale_datetime = Time.now.utc
       @result_set = nil
+      @visited_paths = Set.new
       @force_offset = 0
       @force_exhausted = false
+      @stale_offset = 0
+      @stale_exhausted = false
     end
 
     # Get the file record for the next candidate which needs services run which match the
@@ -38,6 +42,15 @@ module Longleaf
         # given that the page was just retrieved, getting a nil path indicates that the retrieved page of
         # candidates is empty and there are no more candidates to iterate at this time.
         return nil if next_path.nil?
+
+        # Skip paths already encountered in this iteration to prevent infinite loops.
+        # Increment the stale offset so the next page fetch skips past this stuck path.
+        if @visited_paths.include?(next_path)
+          @stale_offset += 1
+          logger.warn("Encountered previously processed path, skipping: #{next_path}")
+          next
+        end
+        @visited_paths.add(next_path)
 
         logger.debug("Retrieved candidate #{next_path}")
         storage_loc = @app_config.location_manager.get_location_by_path(next_path)
@@ -78,7 +91,9 @@ module Longleaf
       else
         case @event
         when EventNames::PRESERVE
-          @result_set = @index_manager.paths_with_stale_services(@file_selector, @stale_datetime)
+          return if @stale_exhausted
+          @result_set = @index_manager.paths_with_stale_services(@file_selector, @stale_datetime, offset: @stale_offset)
+          @stale_exhausted = @result_set.empty?
         when EventNames::CLEANUP
           # TODO
         end

--- a/lib/longleaf/events/preserve_event.rb
+++ b/lib/longleaf/events/preserve_event.rb
@@ -36,9 +36,12 @@ module Longleaf
         if !File.exist?(phys_path)
           # Need to persist metadata to avoid repeating processing of this file too soon.
           needs_persist = true
+          md_rec.failure_timestamp = ServiceDateHelper.formatted_timestamp
           record_failure(EventNames::PRESERVE, f_path, "File is registered but missing.")
           return return_status
         end
+        # Clear any prior missing-file failure state now that the file exists.
+        md_rec.failure_timestamp = nil
 
         # get the list of services applicable to this location and event
         service_manager.list_services(location: storage_loc.name, event: EventNames::PRESERVE).each do |service_name|

--- a/lib/longleaf/indexing/index_manager.rb
+++ b/lib/longleaf/indexing/index_manager.rb
@@ -55,10 +55,11 @@ module Longleaf
     #
     # @param file_selector [FileSelector] selector for paths to search for files
     # @param stale_datetime [DateTime] find file_paths with services needing to be run before this value
+    # @param offset [Integer] number of results to skip, for paging
     # @return [Array] array of file paths that need one or more services run, in ascending order by
     #    timestamp.
-    def paths_with_stale_services(file_selector, stale_datetime)
-      @index_driver.paths_with_stale_services(file_selector, stale_datetime)
+    def paths_with_stale_services(file_selector, stale_datetime, offset: 0)
+      @index_driver.paths_with_stale_services(file_selector, stale_datetime, offset: offset)
     end
 
     # Retrieves a page of paths for registered files.

--- a/lib/longleaf/indexing/sequel_index_driver.rb
+++ b/lib/longleaf/indexing/sequel_index_driver.rb
@@ -225,8 +225,9 @@ module Longleaf
     # Retrieves page of file paths which have one or more services which need to run.
     # @param file_selector [FileSelector] selector for what paths to search for files
     # @param stale_datetime [DateTime] find file_paths with services needing to be run before this value
+    # @param offset [Integer] number of results to skip, for paging
     # @return [Array] array of file paths that need one or more services run.
-    def paths_with_stale_services(file_selector, stale_datetime)
+    def paths_with_stale_services(file_selector, stale_datetime, offset: 0)
       if @preserve_dataset.nil?
         @preserve_dataset = db_conn
             .from(PRESERVE_TBL)
@@ -236,9 +237,10 @@ module Longleaf
       end
 
       # retrieve and return a page of results
-      ds = add_path_restrictions(@preserve_dataset, file_selector)
+      add_path_restrictions(@preserve_dataset, file_selector)
           .where { service_time <= stale_datetime }
           .where { delay_until_time < stale_datetime }
+          .offset(offset)
           .select_map(:file_path)
     end
 

--- a/lib/longleaf/indexing/sequel_index_driver.rb
+++ b/lib/longleaf/indexing/sequel_index_driver.rb
@@ -282,6 +282,14 @@ module Longleaf
       Sequel.connect(conn_details)
     end
 
+    # Disconnects the active database connection, if one has been opened.
+    # Safe to call when no connection is open.
+    def disconnect
+      @connection&.disconnect
+      @connection = nil
+      @preserve_tbl = nil
+    end
+
     private
 
     def db_conn

--- a/lib/longleaf/indexing/sequel_index_driver.rb
+++ b/lib/longleaf/indexing/sequel_index_driver.rb
@@ -128,6 +128,9 @@ module Longleaf
     #    based on the earliest failure timestamp plus the configured failure_retry_delay.
     #    Returns the minimum timestamp if no failures are present.
     def delay_until_timestamp(md_rec)
+      unless md_rec.failure_timestamp.nil?
+        return ServiceDateHelper.add_to_timestamp(md_rec.failure_timestamp, @failure_retry_delay)
+      end
       md_rec.list_services.each do |service_name|
         service_rec = md_rec.service(service_name)
         unless service_rec.failure_timestamp.nil?

--- a/lib/longleaf/models/metadata_record.rb
+++ b/lib/longleaf/models/metadata_record.rb
@@ -12,6 +12,8 @@ module Longleaf
     attr_accessor :file_size, :last_modified, :file_count
     attr_accessor :physical_path
     attr_accessor :object_type
+    # Non-serialized transient field set when a file is missing during preservation.
+    attr_accessor :failure_timestamp
 
     # @param properties [Hash] initial data properties for this record
     # @param services [Hash] initial service property tree

--- a/spec/features/metadata_indexing_spec.rb
+++ b/spec/features/metadata_indexing_spec.rb
@@ -137,6 +137,23 @@ describe 'metadata indexing', :type => :aruba do
       end
     end
 
+    context 'performing preserve event on a registered file whose physical file is missing' do
+      before do
+        run_command_and_stop("longleaf register -c #{config_path} -f #{file_path}", fail_on_error: false)
+        FileUtils.rm(file_path)
+        run_command_and_stop("longleaf preserve -c #{config_path} -f #{file_path} -I #{lib_dir}", fail_on_error: false)
+      end
+
+      it 'records failure and sets delay_until_time on the missing file' do
+        expect(last_command_started).to have_output(/FAILURE preserve #{Regexp.escape(file_path)}: File is registered but missing\./)
+        expect(last_command_started).to have_exit_status(1)
+        row = get_row_from_index(file_path)
+        # Delay must be set to now plus the retry delay (defaults to a day)
+        expected_delay_until = Time.iso8601(Longleaf::ServiceDateHelper.add_to_timestamp(Time.now.iso8601, '1 day'))
+        expect(row[:delay_until_time]).to be_within(60).of(expected_delay_until)
+      end
+    end
+
     context 'deregistering a file' do
       before do
         run_command_and_stop("longleaf register -c #{config_path} -f #{file_path}", fail_on_error: false)

--- a/spec/longleaf/candidates/service_candidate_index_iterator_spec.rb
+++ b/spec/longleaf/candidates/service_candidate_index_iterator_spec.rb
@@ -206,6 +206,20 @@ describe Longleaf::ServiceCandidateIndexIterator do
       end
     end
 
+    context 'with multiple files that keep failing without index update' do
+      let!(:file_rec1) { create_index_file_rec(storage_loc, "serv1", days_from_now(-3)) }
+      let!(:file_rec2) { create_index_file_rec(storage_loc, "serv1", days_from_now(-2)) }
+
+      it 'visits each file exactly once and terminates without infinite loop' do
+        result = Array.new
+        # Intentionally do NOT update the index after processing, so both files
+        # remain stale and would be returned by paths_with_stale_services again.
+        # Without the visited_paths + stale_offset guard this would loop forever.
+        iterator.each { |candidate| result << candidate.path }
+        expect(result).to contain_exactly(file_rec1.path, file_rec2.path)
+      end
+    end
+
     context 'multiple files, some requiring services, one not' do
       let!(:file_rec1) { create_index_file_rec(storage_loc, "serv1", days_from_now(-3)) }
       let!(:file_rec2) { create_index_file_rec(storage_loc, "serv1", days_from_now(3)) }

--- a/spec/longleaf/indexing/sequel_index_driver_spec.rb
+++ b/spec/longleaf/indexing/sequel_index_driver_spec.rb
@@ -25,6 +25,8 @@ describe Longleaf::SequelIndexDriver do
   let(:db_file) { create_test_file(name: 'index.db', content: '') }
 
   after do
+    # Disconnect Sequel connections to avoid exhausting PostgreSQL's max_connections
+    driver.disconnect
     FileUtils.remove_dir(md_dir)
     FileUtils.remove_dir(path_dir)
     FileUtils.rm(db_file)


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5655

* When a file is registered but missing, record a file level failed_timestamp, which gets used when setting the retry delay for services on the record. The failed_timestamp is not persisted to the sidecar metadata file to avoid bloat there for an edge case.
* ServiceCandidateIndexIterator will now also detect when it encounters repeat file paths to avoid other not yet know issues that could trigger infinite loops.