### PR TITLE
Bxc 5546 - Ocfl to S3 replication job

### DIFF
--- a/lib/longleaf/candidates/service_candidate_index_iterator.rb
+++ b/lib/longleaf/candidates/service_candidate_index_iterator.rb
@@ -1,8 +1,6 @@
 require 'longleaf/events/event_names'
 require 'longleaf/errors'
 require 'longleaf/logging'
-require 'longleaf/models/md_fields'
-require 'longleaf/models/storage_types'
 require 'set'
 require 'time'
 
@@ -56,8 +54,7 @@ module Longleaf
 
         logger.debug("Retrieved candidate #{next_path}")
         storage_loc = @app_config.location_manager.get_location_by_path(next_path)
-        object_type = storage_loc.type == StorageTypes::OCFL_STORAGE_TYPE ? MDFields::OCFL_TYPE : nil
-        file_rec = FileRecord.new(next_path, storage_loc, object_type: object_type)
+        file_rec = FileRecord.new(next_path, storage_loc)
 
         # Keep seeking until a registered candidate is found, according to the file system.
         if file_rec.metadata_present?

--- a/lib/longleaf/candidates/service_candidate_index_iterator.rb
+++ b/lib/longleaf/candidates/service_candidate_index_iterator.rb
@@ -1,6 +1,8 @@
 require 'longleaf/events/event_names'
 require 'longleaf/errors'
 require 'longleaf/logging'
+require 'longleaf/models/md_fields'
+require 'longleaf/models/storage_types'
 require 'set'
 require 'time'
 
@@ -54,7 +56,8 @@ module Longleaf
 
         logger.debug("Retrieved candidate #{next_path}")
         storage_loc = @app_config.location_manager.get_location_by_path(next_path)
-        file_rec = FileRecord.new(next_path, storage_loc)
+        object_type = storage_loc.type == StorageTypes::OCFL_STORAGE_TYPE ? MDFields::OCFL_TYPE : nil
+        file_rec = FileRecord.new(next_path, storage_loc, object_type: object_type)
 
         # Keep seeking until a registered candidate is found, according to the file system.
         if file_rec.metadata_present?

--- a/lib/longleaf/cli.rb
+++ b/lib/longleaf/cli.rb
@@ -142,11 +142,6 @@ module Longleaf
         :type => :boolean,
         :default => false,
         :desc => 'Force the registration of already registered files.')
-    method_option(:ocfl,
-        :type => :boolean,
-        :default => false,
-        :desc => %q{If set, the target files will be consider OCFL object directories rather than individual files.
-          Cannot be used with the --manifest option, to submit multiple objects at once use -f or -l})
     method_option(:checksums,
         :desc => %q{Checksums for the submitted file. Only applicable with the -f option.
           Each checksum must be prefaced with an algorithm prefix. Multiple checksums must be comma separated. If multiple files were submitted, they will be provided with the same checksums. For example:

--- a/lib/longleaf/commands/register_command.rb
+++ b/lib/longleaf/commands/register_command.rb
@@ -2,9 +2,9 @@ require 'longleaf/services/application_config_deserializer'
 require 'longleaf/events/register_event'
 require 'longleaf/events/register_ocfl_event'
 require 'longleaf/models/file_record'
+require 'longleaf/models/md_fields'
 require 'longleaf/events/event_names'
 require 'longleaf/events/event_status_tracking'
-require 'longleaf/models/md_fields'
 require 'longleaf/candidates/ocfl_file_selector'
 
 module Longleaf

--- a/lib/longleaf/commands/register_command.rb
+++ b/lib/longleaf/commands/register_command.rb
@@ -2,7 +2,6 @@ require 'longleaf/services/application_config_deserializer'
 require 'longleaf/events/register_event'
 require 'longleaf/events/register_ocfl_event'
 require 'longleaf/models/file_record'
-require 'longleaf/models/md_fields'
 require 'longleaf/events/event_names'
 require 'longleaf/events/event_status_tracking'
 require 'longleaf/candidates/ocfl_file_selector'
@@ -35,8 +34,7 @@ module Longleaf
           storage_location = @app_manager.location_manager.get_location_by_path(f_path)
 
           phys_path = physical_provider.get_physical_path(f_path)
-          object_type = ocfl_mode ? MDFields::OCFL_TYPE : nil
-          file_rec = FileRecord.new(f_path, storage_location, nil, phys_path, object_type: object_type)
+          file_rec = FileRecord.new(f_path, storage_location, nil, phys_path)
 
           if ocfl_mode
             register_event = RegisterOcflEvent.new(file_rec: file_rec, force: force, app_manager: @app_manager,

--- a/lib/longleaf/helpers/selection_options_parser.rb
+++ b/lib/longleaf/helpers/selection_options_parser.rb
@@ -64,7 +64,27 @@ module Longleaf
     end
 
     def self.initialize_file_selector(file_paths, physical_provider, app_config_manager, options)
-      if options[:ocfl]
+      found_ocfl = false
+      found_non_ocfl = false
+
+      file_paths.each do |path|
+        location = app_config_manager.location_manager.get_location_by_path(path)
+        next if location.nil?
+
+        if !location.default_object_type.nil?
+          found_ocfl = true
+        else
+          found_non_ocfl = true
+        end
+
+        break if found_ocfl && found_non_ocfl
+      end
+
+      if found_ocfl && found_non_ocfl
+        raise Longleaf::SelectionError, "Cannot mix OCFL and non-OCFL storage locations in a single operation"
+      end
+
+      if found_ocfl
         return OcflFileSelector.new(file_paths: file_paths,
              physical_provider: physical_provider,
              app_config: app_config_manager)

--- a/lib/longleaf/models/file_record.rb
+++ b/lib/longleaf/models/file_record.rb
@@ -17,7 +17,7 @@ module Longleaf
       @storage_location = storage_location
       @metadata_record = metadata_record
       @physical_path = physical_path
-      @object_type = object_type
+      @object_type = object_type || storage_location.default_object_type
     end
 
     # @return [String] path for the metadata file for this file

--- a/lib/longleaf/models/ocfl_storage_location.rb
+++ b/lib/longleaf/models/ocfl_storage_location.rb
@@ -25,12 +25,15 @@ module Longleaf
   #   * 'work_dir'          - Path to a scratch directory used by ocfl-java for assembling
   #                          object versions. Required by the ocfl-java builder even for
   #                          read-only use. The directory will be created if it does not exist.
+  #   * 'mutable_head'      - Whether objects in this repository use the OCFL mutable head
+  #                          extension (0005-mutable-head). Default: false.
   class OcflStorageLocation < FilesystemStorageLocation
     OCFL_STORAGE_TYPE = 'ocfl'
 
     DIGEST_ALGORITHM_PROPERTY = 'digest_algorithm'
     VERIFY_INVENTORY_PROPERTY = 'verify_inventory'
     WORK_DIR_PROPERTY = 'work_dir'
+    MUTABLE_HEAD_PROPERTY = 'mutable_head'
 
     DEFAULT_DIGEST_ALGORITHM = 'sha512'
 
@@ -41,11 +44,17 @@ module Longleaf
       @work_dir = config[WORK_DIR_PROPERTY]
       raise ArgumentError.new("Parameter '#{WORK_DIR_PROPERTY}' is required for OCFL storage location #{name}") \
           if @work_dir.nil? || @work_dir.empty?
+      @mutable_head = config.key?(MUTABLE_HEAD_PROPERTY) ? config[MUTABLE_HEAD_PROPERTY] : false
     end
 
     # @return the storage type for this location
     def type
       OCFL_STORAGE_TYPE
+    end
+
+    # @return [Boolean] true if objects in this repository use the OCFL mutable head extension
+    def mutable_head?
+      @mutable_head
     end
 
     # Returns a lazily initialized read-only OcflRepository for this storage location.

--- a/lib/longleaf/models/ocfl_storage_location.rb
+++ b/lib/longleaf/models/ocfl_storage_location.rb
@@ -58,6 +58,11 @@ module Longleaf
       @mutable_head
     end
 
+    # @return [String] the default object type for objects in this OCFL storage location
+    def default_object_type
+      MDFields::OCFL_TYPE
+    end
+
     # Override to supply OCFL object type so that the metadata location produces
     # the correct sidecar path for OCFL object directories (which end with '/').
     # For the storage root path itself (empty relative path), returns the metadata

--- a/lib/longleaf/models/ocfl_storage_location.rb
+++ b/lib/longleaf/models/ocfl_storage_location.rb
@@ -4,6 +4,7 @@ end
 
 require 'longleaf/models/filesystem_storage_location'
 require 'longleaf/models/storage_types'
+require 'longleaf/models/md_fields'
 require 'longleaf/errors'
 
 java_import 'io.ocfl.api.DigestAlgorithmRegistry'
@@ -55,6 +56,21 @@ module Longleaf
     # @return [Boolean] true if objects in this repository use the OCFL mutable head extension
     def mutable_head?
       @mutable_head
+    end
+
+    # Override to supply OCFL object type so that the metadata location produces
+    # the correct sidecar path for OCFL object directories (which end with '/').
+    # For the storage root path itself (empty relative path), returns the metadata
+    # root directory so that location-based directory traversal works correctly.
+    def get_metadata_path_for(file_path, object_type: MDFields::OCFL_TYPE)
+      super(file_path, object_type: relativize(file_path).empty? ? nil : object_type)
+    end
+
+    # Override to restore the trailing slash on OCFL object directory paths when
+    # reconstructing them from their metadata sidecar path.
+    def get_path_from_metadata_path(md_path)
+      file_path = super(md_path)
+      file_path.end_with?(File::SEPARATOR) ? file_path : file_path + File::SEPARATOR
     end
 
     # Returns a lazily initialized read-only OcflRepository for this storage location.

--- a/lib/longleaf/models/storage_location.rb
+++ b/lib/longleaf/models/storage_location.rb
@@ -34,6 +34,11 @@ module Longleaf
       @metadata_location.metadata_path_for(rel_file_path, object_type: object_type)
     end
 
+    # @return [String, nil] the default object type for files in this storage location, or nil if not applicable
+    def default_object_type
+      nil
+    end
+
     # @param [String] path to check
     # @return true if the file path is contained by the path for this location
     def contains?(file_path)

--- a/lib/longleaf/preservation_services/ocfl_file_check_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_file_check_service.rb
@@ -34,6 +34,7 @@ module Longleaf
       end
 
       total_size, file_count, last_modified = OcflHelper.summarized_file_info(phys_path)
+      actual_last_modified = last_modified&.utc&.iso8601(3)
 
       if file_count != md_rec.file_count
         raise PreservationServiceError.new("File count for OCFL object #{phys_path} does not match the expected value: registered = #{md_rec.file_count} files, actual = #{file_count} files")
@@ -43,8 +44,8 @@ module Longleaf
         raise PreservationServiceError.new("File size for OCFL object #{phys_path} does not match the expected value: registered = #{md_rec.file_size} bytes, actual = #{total_size} bytes")
       end
 
-      if last_modified != md_rec.last_modified
-        raise PreservationServiceError.new("Last modified timestamp for OCFL object #{phys_path} does not match the expected value: registered = #{md_rec.last_modified}, actual = #{last_modified}")
+      if actual_last_modified != md_rec.last_modified
+        raise PreservationServiceError.new("Last modified timestamp for OCFL object #{phys_path} does not match the expected value: registered = #{md_rec.last_modified}, actual = #{actual_last_modified}")
       end
     end
 

--- a/lib/longleaf/preservation_services/ocfl_rsync_replication_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_rsync_replication_service.rb
@@ -30,7 +30,8 @@ module Longleaf
         rel_path = file_rec.storage_location.relativize(file_rec.path)
 
         options = @options
-        options = options + " -R"
+        # Force recursive copying, and relative paths
+        options = options + " -rR"
         # source path with . so that rsync will only create destination directories starting from that point
         source_path = File.join(file_rec.storage_location.path, "./#{rel_path}")
 

--- a/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
@@ -1,0 +1,249 @@
+require 'digest/md5'
+require 'find'
+require 'longleaf/events/event_names'
+require 'longleaf/logging'
+require 'longleaf/errors'
+require 'longleaf/models/service_fields'
+require 'longleaf/models/storage_types'
+require 'aws-sdk-s3'
+
+module Longleaf
+  # Preservation service which replicates an OCFL object from a local OCFL storage location
+  # to one or more S3 destinations.
+  #
+  # All files under the OCFL object directory are transferred. Files under committed version
+  # directories (vN/) are skipped if they already exist in S3 since they are immutable. All other
+  # files are compared by ETag to detect changes without re-uploading unchanged content.
+  #
+  # S3 objects under the mutable head extension directory (extensions/0005-mutable-head/) that
+  # no longer exist locally due to having been committed to a real version are deleted from the
+  # destination; this is the only case where OCFL legitimately removes files from
+  # an object directory during normal operation.
+  #
+  # The service definition must contain one or more destinations specified with the "to" property.
+  # These destinations must be known S3 storage locations.
+  #
+  # Optional service configuration properties:
+  # * replica_collision_policy = specifies the desired outcome if the service attempts to replicate
+  #     a file which already exists at a destination. Default: "replace".
+  class OcflS3ReplicationService
+    include Longleaf::Logging
+
+    ST ||= Longleaf::StorageTypes
+    SF ||= Longleaf::ServiceFields
+
+    attr_reader :collision_policy
+
+    # Initialize an OcflS3ReplicationService from the given service definition
+    #
+    # @param service_def [ServiceDefinition] the configuration for this service
+    # @param app_manager [ApplicationConfigManager] the application configuration
+    def initialize(service_def, app_manager)
+      @service_def = service_def
+      @app_manager = app_manager
+
+      @collision_policy = @service_def.properties[SF::COLLISION_PROPERTY] || SF::DEFAULT_COLLISION_POLICY
+      unless SF::VALID_COLLISION_POLICIES.include?(@collision_policy)
+        raise ArgumentError.new("Service #{service_def.name} received invalid #{SF::COLLISION_PROPERTY}" \
+            + " value #{@collision_policy}")
+      end
+
+      replicate_to = @service_def.properties[SF::REPLICATE_TO]
+      if replicate_to.nil? || replicate_to.empty?
+        raise ArgumentError.new("Service #{service_def.name} must provide one or more replication destinations.")
+      end
+      replicate_to = [replicate_to] if replicate_to.is_a?(String)
+
+      # Gather and verify s3 destinations
+      loc_manager = app_manager.location_manager
+      @destinations = Array.new
+      replicate_to.each do |dest|
+        if loc_manager.locations.key?(dest)
+          location = loc_manager.locations[dest]
+          if location.type != ST::S3_STORAGE_TYPE
+            raise ArgumentError.new(
+                "Service #{service_def.name} specifies destination #{dest} which is not of type 's3'")
+          end
+          @destinations << location
+        else
+          raise ArgumentError.new("Service #{service_def.name} specifies unknown storage location '#{dest}'" \
+              + " as a replication destination")
+        end
+      end
+    end
+
+    # Replicate the OCFL object to all configured S3 destinations.
+    #
+    # @param file_rec [FileRecord] record representing the OCFL object directory to replicate.
+    # @param event [String] name of the event this service is being invoked by.
+    # @raise [PreservationServiceError] if replication fails
+    def perform(file_rec, event)
+      unless file_rec.storage_location.type == ST::OCFL_STORAGE_TYPE
+        raise PreservationServiceError.new("OcflS3ReplicationService only supports replication from OCFL " \
+            + "storage locations, but source '#{file_rec.storage_location.name}' is of type " \
+            + "'#{file_rec.storage_location.type}'")
+      end
+
+      phys_path = file_rec.physical_path
+      unless Dir.exist?(phys_path)
+        raise PreservationServiceError.new("OCFL object directory does not exist or is not a directory: #{phys_path}")
+      end
+
+      # Path of the OCFL object relative to its storage location root (no leading or trailing slash)
+      rel_path = file_rec.storage_location.relativize(file_rec.path)
+
+      # Collect all local files keyed by their path relative to the object directory
+      local_file_map = build_local_file_map(phys_path)
+
+      @destinations.each do |destination|
+        verify_destination_available(destination, file_rec)
+        upload_files(local_file_map, rel_path, destination, file_rec)
+        remove_deleted_objects(local_file_map, rel_path, destination, file_rec)
+        logger.info("Replicated OCFL object #{file_rec.path} to destination #{destination.name}")
+      end
+    end
+
+    # Determine if this service is applicable for the provided event
+    #
+    # @param event [String] name of the event
+    # @return [Boolean] returns true if this service is applicable for the provided event
+    def is_applicable?(event)
+      case event
+      when EventNames::PRESERVE
+        true
+      else
+        false
+      end
+    end
+
+    private
+
+    # Build a map of all files under the OCFL object directory.
+    #
+    # @param phys_path [String] absolute path to the OCFL object directory
+    # @return [Hash<String, String>] map of path-relative-to-object-dir => absolute-local-path
+    def build_local_file_map(phys_path)
+      obj_dir = phys_path.chomp('/')
+      local_files = {}
+      Find.find(phys_path) do |path|
+        next if File.directory?(path)
+        rel = path.sub("#{obj_dir}/", '')
+        local_files[rel] = path
+      end
+      local_files
+    end
+
+    # Upload local files to S3, skipping any that already exist unchanged.
+    def upload_files(local_file_map, rel_path, destination, file_rec)
+      bucket_name = destination.s3_bucket.name
+      s3_client = destination.s3_client
+
+      local_file_map.each do |rel_within_object, local_path|
+        s3_key = destination.relative_to_bucket_path(File.join(rel_path, rel_within_object))
+
+        if object_unchanged?(s3_client, bucket_name, s3_key, local_path, rel_within_object)
+          logger.debug("Skipping unchanged object at #{s3_key}")
+          next
+        end
+
+        begin
+          destination.s3_bucket.object(s3_key).upload_file(local_path)
+          logger.debug("Uploaded #{local_path} to s3://#{bucket_name}/#{s3_key}")
+        rescue Aws::Errors::ServiceError => e
+          raise PreservationServiceError.new("Failed to transfer #{file_rec.path} (file: #{local_path}) " \
+              + "to bucket '#{bucket_name}': #{e.message}")
+        end
+      end
+    end
+
+    # Regex matching paths relative to the OCFL object root that fall under a committed
+    # version directory (e.g. `v1/`, `v2/`). All files under a version are immutable.
+    VERSIONED_DIR_PATTERN = /\Av\d+\//
+
+    # Returns true if the S3 object can be confirmed unchanged and should be skipped.
+    #
+    # Two strategies are used depending on the file's location within the OCFL object:
+    #
+    # * Files under a committed version directory (`vN/`) — both content files and version
+    #   inventories are immutable once the version is committed. Existence alone is sufficient
+    #   and avoids potentially expensive MD5 computation on large version inventory files.
+    #
+    # * All other files (root inventory/sidecar, namaste, mutable head inventory/sidecar,
+    #   mutable head content, revision markers) — these can change over the life of an object.
+    #   Mutable head content files can be superseded across commit/recreate cycles
+    #   at the same revision path with different content, so existence alone is insufficient.
+    #   The S3 ETag is compared to a locally computed MD5. For single-part uploads the ETag
+    #   is the MD5 hex digest, so this is exact. For multipart uploads (files larger than
+    #   ~15 MB, such as very large root inventories) the ETag is a composite that cannot be
+    #   reproduced locally; size is used as a fallback heuristic in that case.
+    def object_unchanged?(s3_client, bucket_name, s3_key, local_path, rel_within_object)
+      response = s3_client.head_object(bucket: bucket_name, key: s3_key)
+      if versioned_object_file?(rel_within_object)
+        # All vN/ files are immutable once committed — existence is sufficient.
+        true
+      else
+        etag = response.etag.to_s.delete('"')
+        if etag.include?('-')
+          # Multipart ETag — cannot verify against a local MD5; fall back to size.
+          response.content_length == File.size(local_path)
+        else
+          etag == Digest::MD5.file(local_path).hexdigest
+        end
+      end
+    rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+      false
+    end
+
+    # Returns true if the path relative to the OCFL object root falls under a committed
+    # version directory and is therefore immutable.
+    def versioned_object_file?(rel_within_object)
+      VERSIONED_DIR_PATTERN.match?(rel_within_object)
+    end
+
+    # The path prefix within an OCFL object directory for the mutable head extension.
+    # Files here are removed when a mutable head is committed into a real version, making
+    # this the only case in normal OCFL operation where object files are legitimately deleted.
+    MUTABLE_HEAD_EXTENSION_PREFIX = 'extensions/0005-mutable-head/'
+
+    # Delete S3 objects under the mutable head extension prefix that no longer exist locally.
+    #
+    # Deletion is intentionally restricted to the mutable head subtree.  Full object deletion
+    # and non-spec history compression are both out of scope for this service.
+    def remove_deleted_objects(local_file_map, rel_path, destination, file_rec)
+      mutable_head_s3_prefix = destination.relative_to_bucket_path(
+          File.join(rel_path, MUTABLE_HEAD_EXTENSION_PREFIX))
+      bucket_name = destination.s3_bucket.name
+
+      keys_to_delete = []
+      destination.s3_bucket.objects(prefix: mutable_head_s3_prefix).each do |s3_obj|
+        rel_within_object = s3_obj.key[destination.relative_to_bucket_path("#{rel_path}/").length..-1]
+        keys_to_delete << s3_obj.key unless local_file_map.key?(rel_within_object)
+      end
+
+      return if keys_to_delete.empty?
+
+      logger.debug("Removing #{keys_to_delete.size} stale S3 object(s) for #{file_rec.path}")
+      keys_to_delete.each_slice(1000) do |batch|
+        destination.s3_client.delete_objects(
+          bucket: bucket_name,
+          delete: {
+            objects: batch.map { |k| { key: k } },
+            quiet: true
+          }
+        )
+      end
+    rescue Aws::Errors::ServiceError => e
+      raise PreservationServiceError.new("Failed to remove stale objects for #{file_rec.path} " \
+          + "from bucket '#{destination.s3_bucket.name}': #{e.message}")
+    end
+
+    def verify_destination_available(destination, file_rec)
+      begin
+        destination.available?
+      rescue StorageLocationUnavailableError => e
+        raise StorageLocationUnavailableError.new("Cannot replicate #{file_rec.path} to destination " \
+            + "#{destination.name}: #{e.message}")
+      end
+    end
+  end
+end

--- a/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
@@ -167,9 +167,7 @@ module Longleaf
     #
     # Two strategies are used depending on the file's location within the OCFL object:
     #
-    # * Files under a committed version directory (`vN/`) — both content files and version
-    #   inventories are immutable once the version is committed. Existence alone is sufficient
-    #   and avoids potentially expensive MD5 computation on large version inventory files.
+    # * Files under a committed version directory (`vN/`) — Immutable so existence checks are sufficient.
     #
     # * All other files (root inventory/sidecar, namaste, mutable head inventory/sidecar,
     #   mutable head content, revision markers) — these can change over the life of an object.

--- a/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
@@ -139,6 +139,7 @@ module Longleaf
     def upload_files(local_file_map, rel_path, destination, file_rec)
       bucket_name = destination.s3_bucket.name
       s3_client = destination.s3_client
+      transfer_manager = Aws::S3::TransferManager.new(client: s3_client)
 
       local_file_map.each do |rel_within_object, local_path|
         s3_key = destination.relative_to_bucket_path(File.join(rel_path, rel_within_object))
@@ -149,7 +150,7 @@ module Longleaf
         end
 
         begin
-          destination.s3_bucket.object(s3_key).upload_file(local_path)
+          transfer_manager.upload_file(local_path, bucket: bucket_name, key: s3_key)
           logger.debug("Uploaded #{local_path} to s3://#{bucket_name}/#{s3_key}")
         rescue Aws::Errors::ServiceError => e
           raise PreservationServiceError.new("Failed to transfer #{file_rec.path} (file: #{local_path}) " \

--- a/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/ocfl_s3_replication_service.rb
@@ -15,10 +15,11 @@ module Longleaf
   # directories (vN/) are skipped if they already exist in S3 since they are immutable. All other
   # files are compared by ETag to detect changes without re-uploading unchanged content.
   #
-  # S3 objects under the mutable head extension directory (extensions/0005-mutable-head/) that
-  # no longer exist locally due to having been committed to a real version are deleted from the
-  # destination; this is the only case where OCFL legitimately removes files from
-  # an object directory during normal operation.
+  # When the source storage location has mutable head enabled (OcflStorageLocation#mutable_head?
+  # returns true), S3 objects under the mutable head extension directory
+  # (extensions/0005-mutable-head/) that no longer exist locally are deleted from the destination.
+  # This handles the case where a mutable head has been committed into a real version, which is
+  # the only case in normal OCFL operation where object files are legitimately removed.
   #
   # The service definition must contain one or more destinations specified with the "to" property.
   # These destinations must be known S3 storage locations.
@@ -95,10 +96,11 @@ module Longleaf
       # Collect all local files keyed by their path relative to the object directory
       local_file_map = build_local_file_map(phys_path)
 
+      source_loc = file_rec.storage_location
       @destinations.each do |destination|
         verify_destination_available(destination, file_rec)
         upload_files(local_file_map, rel_path, destination, file_rec)
-        remove_deleted_objects(local_file_map, rel_path, destination, file_rec)
+        remove_deleted_objects(local_file_map, rel_path, destination, file_rec) if source_loc.mutable_head?
         logger.info("Replicated OCFL object #{file_rec.path} to destination #{destination.name}")
       end
     end
@@ -206,15 +208,13 @@ module Longleaf
     MUTABLE_HEAD_EXTENSION_PREFIX = 'extensions/0005-mutable-head/'
 
     # Delete S3 objects under the mutable head extension prefix that no longer exist locally.
-    #
-    # Deletion is intentionally restricted to the mutable head subtree.  Full object deletion
-    # and non-spec history compression are both out of scope for this service.
     def remove_deleted_objects(local_file_map, rel_path, destination, file_rec)
       mutable_head_s3_prefix = destination.relative_to_bucket_path(
           File.join(rel_path, MUTABLE_HEAD_EXTENSION_PREFIX))
       bucket_name = destination.s3_bucket.name
 
       keys_to_delete = []
+      # Gather all remote mutable head files as relative paths when they are not present locally
       destination.s3_bucket.objects(prefix: mutable_head_s3_prefix).each do |s3_obj|
         rel_within_object = s3_obj.key[destination.relative_to_bucket_path("#{rel_path}/").length..-1]
         keys_to_delete << s3_obj.key unless local_file_map.key?(rel_within_object)

--- a/lib/longleaf/preservation_services/s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/s3_replication_service.rb
@@ -3,7 +3,6 @@ require 'longleaf/logging'
 require 'longleaf/errors'
 require 'longleaf/models/file_record'
 require 'longleaf/models/service_fields'
-require 'longleaf/events/register_event'
 require 'longleaf/models/storage_types'
 require 'aws-sdk-s3'
 
@@ -56,7 +55,7 @@ module Longleaf
             raise ArgumentError.new(
                 "Service #{service_def.name} specifies destination #{dest} which is not of type 's3'")
           end
-          @destinations << loc_manager.locations[dest]
+          @destinations << location
         else
           raise ArgumentError.new("Service #{service_def.name} specifies unknown storage location '#{dest}'" \
               + " as a replication destination")
@@ -76,6 +75,29 @@ module Longleaf
       else
         raise PreservationServiceError.new("Replication from storage location of type " \
             + "#{file_rec.storage_location.type} to s3 is not supported")
+      end
+    end
+
+    # Determine if this service is applicable for the provided event, given the configured service definition
+    #
+    # @param event [String] name of the event
+    # @return [Boolean] returns true if this service is applicable for the provided event
+    def is_applicable?(event)
+      case event
+      when EventNames::PRESERVE
+        true
+      else
+        false
+      end
+    end
+
+    private
+    def verify_destination_available(destination, file_rec)
+      begin
+        destination.available?
+      rescue StorageLocationUnavailableError => e
+        raise StorageLocationUnavailableError.new("Cannot replicate #{file_rec.path} to destination #{destination.name}: " \
+            + e.message)
       end
     end
 
@@ -102,29 +124,6 @@ module Longleaf
         logger.info("Replicated #{file_rec.path} to s3://#{destination.s3_bucket.name}/#{rel_to_bucket}")
 
         # TODO register file in destination
-      end
-    end
-
-    # Determine if this service is applicable for the provided event, given the configured service definition
-    #
-    # @param event [String] name of the event
-    # @return [Boolean] returns true if this service is applicable for the provided event
-    def is_applicable?(event)
-      case event
-      when EventNames::PRESERVE
-        true
-      else
-        false
-      end
-    end
-
-    private
-    def verify_destination_available(destination, file_rec)
-      begin
-        destination.available?
-      rescue StorageLocationUnavailableError => e
-        raise StorageLocationUnavailableError.new("Cannot replicate #{file_rec.path} to destination #{destination.name}: " \
-            + e.message)
       end
     end
   end

--- a/lib/longleaf/preservation_services/s3_replication_service.rb
+++ b/lib/longleaf/preservation_services/s3_replication_service.rb
@@ -88,9 +88,9 @@ module Longleaf
         verify_destination_available(destination, file_rec)
 
         rel_to_bucket = destination.relative_to_bucket_path(rel_path)
-        file_obj = destination.s3_bucket.object(rel_to_bucket)
+        transfer_manager = Aws::S3::TransferManager.new(client: destination.s3_client)
         begin
-          file_obj.upload_file(file_rec.physical_path)
+          transfer_manager.upload_file(file_rec.physical_path, bucket: destination.s3_bucket.name, key: rel_to_bucket)
         rescue Aws::S3::Errors::BadDigest => e
           raise ChecksumMismatchError.new("Transfer to bucket '#{destination.s3_bucket.name}' failed, " \
               + "MD5 provided did not match the received content for #{file_rec.path}")
@@ -99,7 +99,7 @@ module Longleaf
               + "'#{destination.s3_bucket.name}': #{e.message}")
         end
 
-        logger.info("Replicated #{file_rec.path} to destination #{file_obj.public_url}")
+        logger.info("Replicated #{file_rec.path} to s3://#{destination.s3_bucket.name}/#{rel_to_bucket}")
 
         # TODO register file in destination
       end

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -661,13 +661,20 @@ describe 'register', :type => :aruba do
   end
 
   context 'with OCFL objects' do
+    let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+    let(:ocfl_root_dir) { File.join(path_dir, 'ocfl-root') + '/' }
     let!(:config_path) {
-      ConfigBuilder.new
-        .with_location(name: 'loc1', path: path_dir, md_path: md_dir)
+      b = ConfigBuilder.new
+        .with_location(name: 'loc1', path: ocfl_root_dir, s_type: 'ocfl', md_path: md_dir)
         .with_service(name: 'serv1')
         .map_services('loc1', 'serv1')
-        .write_to_yaml_file
+      b.get['locations']['loc1']['work_dir'] = ocfl_work_dir
+      b.write_to_yaml_file
     }
+
+    after do
+      FileUtils.rm_rf(ocfl_work_dir)
+    end
 
     let(:ocfl_object_path1) { '141/964/af8/141964af842132b7a706ed010474c410514b472acc0d7d8f805c23e748578b8b' }
     let(:ocfl_object_path2) { '51c/fdc/952/51cfdc9524d4088a1259c0c099ec2c6e9c82f69beda7920911c105e56810eeeb' }
@@ -682,7 +689,7 @@ describe 'register', :type => :aruba do
 
     context 'register OCFL object with -f parameter' do
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --ocfl", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
       end
 
       it 'registers the OCFL object' do
@@ -700,8 +707,8 @@ describe 'register', :type => :aruba do
 
     context 'register OCFL object more than once with force flag' do
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --ocfl", fail_on_error: false)
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --ocfl --force", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
+        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --force", fail_on_error: false)
       end
 
       it 'registers the OCFL object' do
@@ -723,7 +730,7 @@ describe 'register', :type => :aruba do
                        "#{ocfl_path2}") }
 
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -l '#{list_file}' --ocfl")
+        run_command_and_stop("longleaf register -c #{config_path} -l '#{list_file}'")
       end
 
       it 'registers both OCFL objects' do
@@ -748,19 +755,6 @@ describe 'register', :type => :aruba do
       end
     end
 
-    context 'register OCFL object with -s parameter' do
-      before do
-        run_command_and_stop("longleaf register -c #{config_path} -s 'loc1'", fail_on_error: false)
-      end
-
-      it 'does not register directories as files' do
-        expect(last_command_started).to_not have_output(/SUCCESS register #{ocfl_path1}/)
-        expect(last_command_started).to_not have_output(/SUCCESS register #{ocfl_path2}/)
-        expect(metadata_created(ocfl_path1, md_dir)).to be false
-        expect(metadata_created(ocfl_path2, md_dir)).to be false
-        expect(last_command_started).to have_exit_status(0)
-      end
-    end
   end
 
   def get_metadata_record_path(file_path, md_dir)
@@ -776,7 +770,7 @@ describe 'register', :type => :aruba do
   end
 
   def get_ocfl_metadata_record_path(file_path, md_dir)
-    File.join(md_dir, 'ocfl-root', file_path + Longleaf::MetadataSerializer::metadata_suffix)
+    File.join(md_dir, file_path + Longleaf::MetadataSerializer::metadata_suffix)
   end
 
   def get_ocfl_metadata_record(file_path, md_dir)

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -660,6 +660,7 @@ describe 'register', :type => :aruba do
     end
   end
 
+  if RUBY_ENGINE == 'jruby'
   context 'with OCFL objects' do
     let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
     let(:ocfl_root_dir) { File.join(path_dir, 'ocfl-root') + '/' }
@@ -756,6 +757,7 @@ describe 'register', :type => :aruba do
     end
 
   end
+  end # jruby only
 
   def get_metadata_record_path(file_path, md_dir)
     File.join(md_dir, File.basename(file_path) + Longleaf::MetadataSerializer::metadata_suffix)

--- a/spec/features/register_command_spec.rb
+++ b/spec/features/register_command_spec.rb
@@ -661,102 +661,102 @@ describe 'register', :type => :aruba do
   end
 
   if RUBY_ENGINE == 'jruby'
-  context 'with OCFL objects' do
-    let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
-    let(:ocfl_root_dir) { File.join(path_dir, 'ocfl-root') + '/' }
-    let!(:config_path) {
-      b = ConfigBuilder.new
-        .with_location(name: 'loc1', path: ocfl_root_dir, s_type: 'ocfl', md_path: md_dir)
-        .with_service(name: 'serv1')
-        .map_services('loc1', 'serv1')
-      b.get['locations']['loc1']['work_dir'] = ocfl_work_dir
-      b.write_to_yaml_file
-    }
+    context 'with OCFL objects' do
+      let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+      let(:ocfl_root_dir) { File.join(path_dir, 'ocfl-root') + '/' }
+      let!(:config_path) {
+        b = ConfigBuilder.new
+          .with_location(name: 'loc1', path: ocfl_root_dir, s_type: 'ocfl', md_path: md_dir)
+          .with_service(name: 'serv1')
+          .map_services('loc1', 'serv1')
+        b.get['locations']['loc1']['work_dir'] = ocfl_work_dir
+        b.write_to_yaml_file
+      }
 
-    after do
-      FileUtils.rm_rf(ocfl_work_dir)
-    end
-
-    let(:ocfl_object_path1) { '141/964/af8/141964af842132b7a706ed010474c410514b472acc0d7d8f805c23e748578b8b' }
-    let(:ocfl_object_path2) { '51c/fdc/952/51cfdc9524d4088a1259c0c099ec2c6e9c82f69beda7920911c105e56810eeeb' }
-    let!(:ocfl_path1) { File.join(path_dir, 'ocfl-root', ocfl_object_path1) }
-    let!(:ocfl_path2) { File.join(path_dir, 'ocfl-root', ocfl_object_path2) }
-
-    before do
-      # Copy OCFL fixtures into path_dir, preserving timestamps
-      fixtures_path = File.join(__dir__, '../fixtures/ocfl-root')
-      FileUtils.cp_r(fixtures_path, path_dir, preserve: true)
-    end
-
-    context 'register OCFL object with -f parameter' do
-      before do
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
+      after do
+        FileUtils.rm_rf(ocfl_work_dir)
       end
 
-      it 'registers the OCFL object' do
-        expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
-        expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
-
-        md_rec = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
-        expect(md_rec.file_size).to eq 2819
-        expect(md_rec.file_count).to eq 7
-        expect(md_rec.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
-        expect(md_rec.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
-        expect(last_command_started).to have_exit_status(0)
-      end
-    end
-
-    context 'register OCFL object more than once with force flag' do
-      before do
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
-        run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --force", fail_on_error: false)
-      end
-
-      it 'registers the OCFL object' do
-        expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
-        expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
-
-        md_rec = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
-        expect(md_rec.file_size).to eq 2819
-        expect(md_rec.file_count).to eq 7
-        expect(md_rec.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
-        expect(md_rec.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
-        expect(last_command_started).to have_exit_status(0)
-      end
-    end
-
-    context 'register multiple OCFL objects with -l parameter' do
-      let!(:list_file) { create_test_file(dir: path_dir, name: "ocfl_list.txt", content:
-                       "#{ocfl_path1}\n" +
-                       "#{ocfl_path2}") }
+      let(:ocfl_object_path1) { '141/964/af8/141964af842132b7a706ed010474c410514b472acc0d7d8f805c23e748578b8b' }
+      let(:ocfl_object_path2) { '51c/fdc/952/51cfdc9524d4088a1259c0c099ec2c6e9c82f69beda7920911c105e56810eeeb' }
+      let!(:ocfl_path1) { File.join(path_dir, 'ocfl-root', ocfl_object_path1) }
+      let!(:ocfl_path2) { File.join(path_dir, 'ocfl-root', ocfl_object_path2) }
 
       before do
-        run_command_and_stop("longleaf register -c #{config_path} -l '#{list_file}'")
+        # Copy OCFL fixtures into path_dir, preserving timestamps
+        fixtures_path = File.join(__dir__, '../fixtures/ocfl-root')
+        FileUtils.cp_r(fixtures_path, path_dir, preserve: true)
       end
 
-      it 'registers both OCFL objects' do
-        expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
-        expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
-        expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path2}/)
-        expect(ocfl_metadata_created(ocfl_object_path2, md_dir)).to be true
+      context 'register OCFL object with -f parameter' do
+        before do
+          run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
+        end
 
-        md_rec1 = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
-        expect(md_rec1.file_size).to eq 2819
-        expect(md_rec1.file_count).to eq 7
-        expect(md_rec1.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
-        expect(md_rec1.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
+        it 'registers the OCFL object' do
+          expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
+          expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
 
-        md_rec2 = get_ocfl_metadata_record(ocfl_object_path2, md_dir)
-        expect(md_rec2.file_size).to eq 2912
-        expect(md_rec2.file_count).to eq 7
-        expect(md_rec2.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
-        expect(md_rec2.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
-
-        expect(last_command_started).to have_exit_status(0)
+          md_rec = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
+          expect(md_rec.file_size).to eq 2819
+          expect(md_rec.file_count).to eq 7
+          expect(md_rec.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
+          expect(md_rec.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
+          expect(last_command_started).to have_exit_status(0)
+        end
       end
+
+      context 'register OCFL object more than once with force flag' do
+        before do
+          run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}'", fail_on_error: false)
+          run_command_and_stop("longleaf register -c #{config_path} -f '#{ocfl_path1}' --force", fail_on_error: false)
+        end
+
+        it 'registers the OCFL object' do
+          expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
+          expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
+
+          md_rec = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
+          expect(md_rec.file_size).to eq 2819
+          expect(md_rec.file_count).to eq 7
+          expect(md_rec.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
+          expect(md_rec.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
+          expect(last_command_started).to have_exit_status(0)
+        end
+      end
+
+      context 'register multiple OCFL objects with -l parameter' do
+        let!(:list_file) { create_test_file(dir: path_dir, name: "ocfl_list.txt", content:
+                        "#{ocfl_path1}\n" +
+                        "#{ocfl_path2}") }
+
+        before do
+          run_command_and_stop("longleaf register -c #{config_path} -l '#{list_file}'")
+        end
+
+        it 'registers both OCFL objects' do
+          expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path1}/)
+          expect(ocfl_metadata_created(ocfl_object_path1, md_dir)).to be true
+          expect(last_command_started).to have_output(/SUCCESS register #{ocfl_path2}/)
+          expect(ocfl_metadata_created(ocfl_object_path2, md_dir)).to be true
+
+          md_rec1 = get_ocfl_metadata_record(ocfl_object_path1, md_dir)
+          expect(md_rec1.file_size).to eq 2819
+          expect(md_rec1.file_count).to eq 7
+          expect(md_rec1.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
+          expect(md_rec1.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
+
+          md_rec2 = get_ocfl_metadata_record(ocfl_object_path2, md_dir)
+          expect(md_rec2.file_size).to eq 2912
+          expect(md_rec2.file_count).to eq 7
+          expect(md_rec2.last_modified).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:/)
+          expect(md_rec2.object_type).to eq(Longleaf::MDFields::OCFL_TYPE)
+
+          expect(last_command_started).to have_exit_status(0)
+        end
+      end
+
     end
-
-  end
   end # jruby only
 
   def get_metadata_record_path(file_path, md_dir)

--- a/spec/longleaf/candidates/registered_file_selector_spec.rb
+++ b/spec/longleaf/candidates/registered_file_selector_spec.rb
@@ -258,8 +258,7 @@ describe Longleaf::RegisteredFileSelector do
       object_path = File.join(ocfl_root, obj_name) + '/'
       FileUtils.mkdir_p(object_path)
       storage_loc = ocfl_app_config.location_manager.get_location_by_path(object_path)
-      file_rec = Longleaf::FileRecord.new(object_path, storage_loc, nil, nil,
-                                          object_type: Longleaf::MDFields::OCFL_TYPE)
+      file_rec = Longleaf::FileRecord.new(object_path, storage_loc)
       MetadataBuilder.new.write_to_yaml_file(file_rec: file_rec)
       object_path
     end

--- a/spec/longleaf/candidates/registered_file_selector_spec.rb
+++ b/spec/longleaf/candidates/registered_file_selector_spec.rb
@@ -7,6 +7,12 @@ require 'support/shared_examples/file_selector_examples'
 require 'longleaf/errors'
 require 'fileutils'
 
+if RUBY_ENGINE == 'jruby'
+  require 'longleaf/models/ocfl_storage_location'
+  require 'longleaf/models/md_fields'
+  require 'longleaf/models/app_fields'
+end
+
 describe Longleaf::RegisteredFileSelector do
   include Longleaf::FileHelpers
   ConfigBuilder ||= Longleaf::ConfigBuilder
@@ -160,6 +166,82 @@ describe Longleaf::RegisteredFileSelector do
         expect { selector.next_path }.to raise_error(Longleaf::StorageLocationUnavailableError)
       end
     end
+
+    if RUBY_ENGINE == 'jruby'
+      OcflStorageLocation ||= Longleaf::OcflStorageLocation
+      MDFields ||= Longleaf::MDFields
+      AF ||= Longleaf::AppFields
+
+      context 'with OCFL storage location' do
+        let(:ocfl_root) { Dir.mktmpdir('ocfl-root') }
+        let(:ocfl_md_dir) { Dir.mktmpdir('ocfl-metadata') }
+        let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+
+        let(:ocfl_config) {
+          c = ConfigBuilder.new
+            .with_services
+            .with_location(name: 'ocfl_loc', path: ocfl_root, s_type: 'ocfl', md_path: ocfl_md_dir)
+            .with_mappings
+            .get
+          c[AF::LOCATIONS]['ocfl_loc'][OcflStorageLocation::WORK_DIR_PROPERTY] = ocfl_work_dir
+          c
+        }
+        let(:ocfl_app_config) { build(:application_config_manager, config: ocfl_config) }
+
+        after do
+          FileUtils.rm_rf([ocfl_root, ocfl_md_dir, ocfl_work_dir])
+        end
+
+        context 'with a registered OCFL object path' do
+          let(:object_path) { create_registered_ocfl_object(ocfl_root, ocfl_app_config) }
+          let(:selector) {
+            build(:registered_file_selector,
+                  file_paths: [object_path],
+                  app_config: ocfl_app_config)
+          }
+
+          it 'returns the OCFL object path with trailing slash' do
+            expect(selector.next_path).to eq object_path
+            expect(selector.next_path).to be_nil
+          end
+        end
+
+        context 'with an unregistered OCFL object (directory exists, no metadata)' do
+          let(:object_path) {
+            path = File.join(ocfl_root, 'unregistered_obj') + '/'
+            FileUtils.mkdir_p(path)
+            path
+          }
+          let(:selector) {
+            build(:registered_file_selector,
+                  file_paths: [object_path],
+                  app_config: ocfl_app_config)
+          }
+
+          it 'raises RegistrationError' do
+            expect { selector.next_path }.to raise_error(Longleaf::RegistrationError)
+          end
+        end
+
+        context 'with multiple registered OCFL objects selected by storage location' do
+          let!(:object_path1) { create_registered_ocfl_object(ocfl_root, ocfl_app_config, 'obj1') }
+          let!(:object_path2) { create_registered_ocfl_object(ocfl_root, ocfl_app_config, 'obj2') }
+          let(:selector) {
+            build(:registered_file_selector,
+                  storage_locations: ['ocfl_loc'],
+                  app_config: ocfl_app_config)
+          }
+
+          it 'returns all registered OCFL objects' do
+            results = []
+            while (path = selector.next_path)
+              results << path
+            end
+            expect(results).to contain_exactly(object_path1, object_path2)
+          end
+        end
+      end
+    end
   end
 
   def create_registered_file(path_dir, file_prefix = nil)
@@ -169,5 +251,17 @@ describe Longleaf::RegisteredFileSelector do
     MetadataBuilder.new(file_path: file_path)
         .write_to_yaml_file(file_rec: file_rec)
     file_path
+  end
+
+  if RUBY_ENGINE == 'jruby'
+    def create_registered_ocfl_object(ocfl_root, ocfl_app_config, obj_name = 'test_obj')
+      object_path = File.join(ocfl_root, obj_name) + '/'
+      FileUtils.mkdir_p(object_path)
+      storage_loc = ocfl_app_config.location_manager.get_location_by_path(object_path)
+      file_rec = Longleaf::FileRecord.new(object_path, storage_loc, nil, nil,
+                                          object_type: Longleaf::MDFields::OCFL_TYPE)
+      MetadataBuilder.new.write_to_yaml_file(file_rec: file_rec)
+      object_path
+    end
   end
 end

--- a/spec/longleaf/candidates/registered_file_selector_spec.rb
+++ b/spec/longleaf/candidates/registered_file_selector_spec.rb
@@ -201,7 +201,9 @@ describe Longleaf::RegisteredFileSelector do
           }
 
           it 'returns the OCFL object path with trailing slash' do
-            expect(selector.next_path).to eq object_path
+            path = selector.next_path
+            expect(path).to eq object_path
+            expect(path).to end_with('/')
             expect(selector.next_path).to be_nil
           end
         end

--- a/spec/longleaf/helpers/selection_options_parser_spec.rb
+++ b/spec/longleaf/helpers/selection_options_parser_spec.rb
@@ -375,9 +375,7 @@ describe Longleaf::SelectionOptionsParser do
           list_file.write(ocfl_path1 + "\n")
           list_file.write(ocfl_path2 + "\n")
           list_file.rewind
-        end
 
-        before do
           fixtures_path = File.join(__dir__, '../../fixtures/ocfl-root')
           FileUtils.cp_r(fixtures_path, path_dir1, preserve: true)
         end

--- a/spec/longleaf/helpers/selection_options_parser_spec.rb
+++ b/spec/longleaf/helpers/selection_options_parser_spec.rb
@@ -177,21 +177,71 @@ describe Longleaf::SelectionOptionsParser do
         expect(collect_paths(selector)).to eq [file_path1, file_path2]
       end
 
-      context 'with ocfl objects' do
-        before do
-          fixtures_path = File.join(__dir__, '../../fixtures/ocfl-root')
-          FileUtils.cp_r(fixtures_path, path_dir1, preserve: true)
+      if RUBY_ENGINE == 'jruby'
+        OcflStorageLocation ||= Longleaf::OcflStorageLocation
+        AF ||= Longleaf::AppFields
+
+        context 'with ocfl objects' do
+          let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+          let(:ocfl_config) {
+            c = ConfigBuilder.new
+              .with_services
+              .with_location(name: 'loc1', path: path_dir1, s_type: 'ocfl', md_path: md_dir1)
+              .with_mappings
+              .get
+            c[AF::LOCATIONS]['loc1'][OcflStorageLocation::WORK_DIR_PROPERTY] = ocfl_work_dir
+            c
+          }
+          let(:ocfl_app_config_manager) { build(:application_config_manager, config: ocfl_config) }
+
+          before do
+            fixtures_path = File.join(__dir__, '../../fixtures/ocfl-root')
+            FileUtils.cp_r(fixtures_path, path_dir1, preserve: true)
+          end
+
+          after do
+            FileUtils.rm_rf(ocfl_work_dir)
+          end
+
+          it 'returns selector for single file' do
+            options = { file: ocfl_path1 }
+
+            selector, digest_provider, physical_provider = SelectionOptionsParser.parse_registration_selection_options(options, ocfl_app_config_manager)
+
+            expect(selector).to be_a(OcflFileSelector)
+            expect(collect_paths(selector)).to eq [expected_ocfl_path1]
+            expect(digest_provider).to be_nil
+            expect(physical_provider).to be_a(PhysicalPathProvider)
+          end
         end
 
-        it 'returns selector for single file with OCFL flag' do
-          options = { file: ocfl_path1, ocfl: true }
+        context 'with mixed ocfl and non-ocfl locations' do
+          let(:path_dir2) { make_test_dir(name: 'path2') }
+          let(:md_dir2) { make_test_dir(name: 'metadata2') }
+          let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+          let(:mixed_ocfl_path) { File.join(path_dir2, ocfl_object_path1) }
+          let(:mixed_config) {
+            c = ConfigBuilder.new
+              .with_services
+              .with_location(name: 'loc1', path: path_dir1, md_path: md_dir1)
+              .with_location(name: 'loc2', path: path_dir2, s_type: 'ocfl', md_path: md_dir2)
+              .with_mappings
+              .get
+            c[AF::LOCATIONS]['loc2'][OcflStorageLocation::WORK_DIR_PROPERTY] = ocfl_work_dir
+            c
+          }
+          let(:mixed_app_config_manager) { build(:application_config_manager, config: mixed_config) }
 
-          selector, digest_provider, physical_provider = SelectionOptionsParser.parse_registration_selection_options(options, app_config_manager)
+          after do
+            FileUtils.rm_rf([path_dir2, md_dir2, ocfl_work_dir])
+          end
 
-          expect(selector).to be_a(OcflFileSelector)
-          expect(collect_paths(selector)).to eq [expected_ocfl_path1]
-          expect(digest_provider).to be_nil
-          expect(physical_provider).to be_a(PhysicalPathProvider)
+          it 'raises SelectionError when mixing OCFL and non-OCFL paths' do
+            options = { file: "#{file_path1}, #{mixed_ocfl_path}" }
+
+            expect { SelectionOptionsParser.parse_registration_selection_options(options, mixed_app_config_manager) }
+              .to raise_error(Longleaf::SelectionError, /Cannot mix OCFL and non-OCFL/)
+          end
         end
       end
 
@@ -297,34 +347,51 @@ describe Longleaf::SelectionOptionsParser do
       end
     end
 
-    context 'with from_list option and ocfl objects' do
-      let(:list_file) { Tempfile.new(['filelist', '.txt']) }
+    if RUBY_ENGINE == 'jruby'
+      OcflStorageLocation ||= Longleaf::OcflStorageLocation
+      AF ||= Longleaf::AppFields
 
-      after do
-        list_file.close
-        list_file.unlink
-      end
+      context 'with from_list option and ocfl objects' do
+        let(:list_file) { Tempfile.new(['filelist', '.txt']) }
+        let(:ocfl_work_dir) { Dir.mktmpdir('ocfl-work') }
+        let(:ocfl_config) {
+          c = ConfigBuilder.new
+            .with_services
+            .with_location(name: 'loc1', path: path_dir1, s_type: 'ocfl', md_path: md_dir1)
+            .with_mappings
+            .get
+          c[AF::LOCATIONS]['loc1'][OcflStorageLocation::WORK_DIR_PROPERTY] = ocfl_work_dir
+          c
+        }
+        let(:ocfl_app_config_manager) { build(:application_config_manager, config: ocfl_config) }
 
-      before do
-        list_file.write(ocfl_path1 + "\n")
-        list_file.write(ocfl_path2 + "\n")
-        list_file.rewind
-      end
+        after do
+          list_file.close
+          list_file.unlink
+          FileUtils.rm_rf(ocfl_work_dir)
+        end
 
-      before do
-        fixtures_path = File.join(__dir__, '../../fixtures/ocfl-root')
-        FileUtils.cp_r(fixtures_path, path_dir1, preserve: true)
-      end
+        before do
+          list_file.write(ocfl_path1 + "\n")
+          list_file.write(ocfl_path2 + "\n")
+          list_file.rewind
+        end
 
-      it 'returns selector from file list with correct file paths with OCFL flag' do
-        options = { from_list: list_file.path, ocfl: true }
+        before do
+          fixtures_path = File.join(__dir__, '../../fixtures/ocfl-root')
+          FileUtils.cp_r(fixtures_path, path_dir1, preserve: true)
+        end
 
-        selector, digest_provider, physical_provider = SelectionOptionsParser.parse_registration_selection_options(options, app_config_manager)
+        it 'returns selector from file list with correct file paths' do
+          options = { from_list: list_file.path }
 
-        expect(selector).to be_a(OcflFileSelector)
-        expect(collect_paths(selector)).to eq [expected_ocfl_path1, expected_ocfl_path2]
-        expect(digest_provider).to be_nil
-        expect(physical_provider).to be_a(PhysicalPathProvider)
+          selector, digest_provider, physical_provider = SelectionOptionsParser.parse_registration_selection_options(options, ocfl_app_config_manager)
+
+          expect(selector).to be_a(OcflFileSelector)
+          expect(collect_paths(selector)).to eq [expected_ocfl_path1, expected_ocfl_path2]
+          expect(digest_provider).to be_nil
+          expect(physical_provider).to be_a(PhysicalPathProvider)
+        end
       end
     end
 

--- a/spec/longleaf/models/ocfl_storage_location_spec.rb
+++ b/spec/longleaf/models/ocfl_storage_location_spec.rb
@@ -3,8 +3,13 @@ require 'spec_helper'
 if RUBY_ENGINE == 'jruby'
   require 'longleaf/models/ocfl_storage_location'
   require 'longleaf/models/app_fields'
+  require 'longleaf/services/metadata_serializer'
+  require 'fileutils'
+  require 'tmpdir'
 
   describe Longleaf::OcflStorageLocation do
+
+    OCFL_OBJECT_REL_PATH ||= '141/964/af8/141964af842132b7a706ed010474c410514b472acc0d7d8f805c23e748578b8b'
 
     describe '.initialize' do
       context 'with no config' do
@@ -84,6 +89,42 @@ if RUBY_ENGINE == 'jruby'
 
         it 'raises an ArgumentError when the repository is first accessed' do
           expect { location.ocfl_repository }.to raise_error(ArgumentError, /sha3-256/)
+        end
+      end
+    end
+
+    describe '.get_metadata_path_for' do
+      let(:md_dir) { Dir.mktmpdir('metadata') }
+      let(:location) { build(:ocfl_storage_location, metadata_path: md_dir) }
+
+      after { FileUtils.rm_rf(md_dir) }
+
+      context 'with an OCFL object directory path' do
+        it 'returns the sidecar metadata path without requiring explicit object_type' do
+          object_path = File.join(location.path, OCFL_OBJECT_REL_PATH) + '/'
+          expected = File.join(md_dir, OCFL_OBJECT_REL_PATH) + Longleaf::MetadataSerializer.metadata_suffix
+          expect(location.get_metadata_path_for(object_path)).to eq expected
+        end
+      end
+
+      context 'with the storage root path' do
+        it 'returns the metadata root directory to allow directory traversal' do
+          expect(location.get_metadata_path_for(location.path)).to eq location.metadata_location.path
+        end
+      end
+    end
+
+    describe '.get_path_from_metadata_path' do
+      let(:md_dir) { Dir.mktmpdir('metadata') }
+      let(:location) { build(:ocfl_storage_location, metadata_path: md_dir) }
+
+      after { FileUtils.rm_rf(md_dir) }
+
+      context 'with an OCFL sidecar metadata path' do
+        it 'returns the OCFL object directory path with a trailing slash' do
+          sidecar_path = File.join(md_dir, OCFL_OBJECT_REL_PATH) + Longleaf::MetadataSerializer.metadata_suffix
+          expected = File.join(location.path, OCFL_OBJECT_REL_PATH) + '/'
+          expect(location.get_path_from_metadata_path(sidecar_path)).to eq expected
         end
       end
     end

--- a/spec/longleaf/preservation_services/ocfl_file_check_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_file_check_service_spec.rb
@@ -110,7 +110,7 @@ describe Longleaf::OcflFileCheckService do
 
       it 'raises PreservationServiceError' do
         expect { service.perform(file_rec, PRESERVE_EVENT) }.to raise_error(PreservationServiceError,
-            /Last modified timestamp for OCFL object #{file_rec.physical_path} does not match the expected value/)
+            /Last modified timestamp for OCFL object #{file_rec.physical_path} does not match the expected value: registered = .+, actual = \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
       end
     end
 
@@ -173,7 +173,7 @@ describe Longleaf::OcflFileCheckService do
 
     MetadataBuilder.new(file_path: file_path)
         .with_file_count(file_count)
-        .with_last_modified(last_modified)
+        .with_last_modified(last_modified&.utc&.iso8601(3))
         .with_file_size(total_size)
         .with_object_type(MDFields::OCFL_TYPE)
         .register_to(file_rec)

--- a/spec/longleaf/preservation_services/ocfl_rsync_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_rsync_replication_service_spec.rb
@@ -170,8 +170,9 @@ describe Longleaf::OcflRsyncReplicationService do
 
         replica_path = File.join(path_dest_dir, 'ocfl-root', ocfl_object_path)
 
-        # Verify all files exist in replica
+        # Verify all files exist in replica, including files in nested subdirectories
         expect(Dir.exist?(replica_path)).to be true
+        expect(File.exist?(File.join(replica_path, 'v1', 'content', '.fcrepo', 'fcr-root.json'))).to be true
         verify_all_files_replicated(original_object_path, replica_path)
 
         # Verify metadata was created

--- a/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'longleaf/errors'
 require 'longleaf/preservation_services/ocfl_s3_replication_service'
+require 'longleaf/models/md_fields'
 require 'longleaf/models/service_fields'
 require 'longleaf/models/storage_types'
 require 'longleaf/specs/file_helpers'
@@ -55,6 +56,7 @@ describe Longleaf::OcflS3ReplicationService do
     )
     allow(loc).to receive(:relativize) { |fp| fp.sub(/\A#{Regexp.escape(path.chomp('/'))}\// , '') }
     allow(loc).to receive(:mutable_head?).and_return(mutable_head)
+    allow(loc).to receive(:default_object_type).and_return(Longleaf::MDFields::OCFL_TYPE)
     loc
   end
 

--- a/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
@@ -47,13 +47,14 @@ describe Longleaf::OcflS3ReplicationService do
   end
 
   # Build a stub OCFL storage location that reports type 'ocfl' and can relativize paths.
-  def build_ocfl_location(path: path_src_dir, md_path: md_src_dir)
+  def build_ocfl_location(path: path_src_dir, md_path: md_src_dir, mutable_head: false)
     loc = instance_double('Longleaf::OcflStorageLocation',
       name: 'ocfl_src',
       type: ST::OCFL_STORAGE_TYPE,
       path: path
     )
-    allow(loc).to receive(:relativize) { |fp| fp.sub(/\A#{Regexp.escape(path.chomp('/'))}\//, '') }
+    allow(loc).to receive(:relativize) { |fp| fp.sub(/\A#{Regexp.escape(path.chomp('/'))}\// , '') }
+    allow(loc).to receive(:mutable_head?).and_return(mutable_head)
     loc
   end
 
@@ -380,6 +381,7 @@ describe Longleaf::OcflS3ReplicationService do
     end
 
     context 'mutable head cleanup' do
+      let(:source_loc)   { build_ocfl_location(mutable_head: true) }
       let(:mutable_head_dir) do
         dir = File.join(ocfl_object_path, 'extensions', '0005-mutable-head')
         FileUtils.mkdir_p(File.join(dir, 'head', 'content', 'r1'))
@@ -493,6 +495,38 @@ describe Longleaf::OcflS3ReplicationService do
             .select { |r| r[:operation_name] == :delete_objects }
           expect(delete_requests).to be_empty
         end
+      end
+    end
+
+    context 'when the source location does not have mutable head enabled' do
+      let(:stale_key) { "#{s3_object_prefix}/extensions/0005-mutable-head/head/content/r1/old_file.bin" }
+      let(:mutable_head_prefix) { "#{s3_object_prefix}/extensions/0005-mutable-head/" }
+
+      before do
+        dest.s3_client.stub_responses(:list_objects_v2,
+          ->(context) {
+            if context.params[:prefix] == mutable_head_prefix
+              {
+                contents: [{ key: stale_key, size: 100, etag: '"abc"' }],
+                is_truncated: false
+              }
+            else
+              { contents: [], is_truncated: false }
+            end
+          }
+        )
+      end
+
+      it 'does not perform mutable head cleanup' do
+        service.perform(file_rec, PRESERVE_EVENT)
+
+        list_requests = dest.s3_client.api_requests
+          .select { |r| r[:operation_name] == :list_objects_v2 }
+        delete_requests = dest.s3_client.api_requests
+          .select { |r| r[:operation_name] == :delete_objects }
+
+        expect(list_requests).to be_empty
+        expect(delete_requests).to be_empty
       end
     end
 

--- a/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
@@ -1,0 +1,542 @@
+require 'spec_helper'
+require 'longleaf/errors'
+require 'longleaf/preservation_services/ocfl_s3_replication_service'
+require 'longleaf/models/service_fields'
+require 'longleaf/models/storage_types'
+require 'longleaf/specs/file_helpers'
+require 'digest/md5'
+require 'fileutils'
+require 'find'
+require 'tmpdir'
+
+describe Longleaf::OcflS3ReplicationService do
+  include Longleaf::FileHelpers
+
+  SF   ||= Longleaf::ServiceFields
+  ST   ||= Longleaf::StorageTypes
+  OcflS3Service ||= Longleaf::OcflS3ReplicationService
+  PRESERVE_EVENT ||= Longleaf::EventNames::PRESERVE
+  PreservationServiceError ||= Longleaf::PreservationServiceError
+
+  OCFL_OBJECT_REL_PATH = '141/964/af8/141964af842132b7a706ed010474c410514b472acc0d7d8f805c23e748578b8b'
+  OCFL_FIXTURE_PATH = File.expand_path('../../fixtures/ocfl-root', __dir__) + File::SEPARATOR
+
+  # ── shared infrastructure ──────────────────────────────────────────────────
+
+  let(:md_dest_dir)  { Dir.mktmpdir('dest_metadata') }
+  let(:md_src_dir)   { Dir.mktmpdir('src_metadata') }
+  let(:path_src_dir) { Dir.mktmpdir('src_path') }
+
+  after(:each) do
+    FileUtils.rm_rf([md_dest_dir, md_src_dir, path_src_dir])
+  end
+
+  # Copies the OCFL fixtures into path_src_dir so tests can mutate freely.
+  def setup_ocfl_fixture
+    FileUtils.cp_r(OCFL_FIXTURE_PATH, path_src_dir)
+  end
+
+  def ocfl_object_path
+    File.join(path_src_dir, 'ocfl-root', OCFL_OBJECT_REL_PATH)
+  end
+
+  # S3 key prefix for files in the OCFL object: includes the bucket subpath + the
+  # path of the object relative to the storage location root (which includes 'ocfl-root/').
+  def s3_object_prefix
+    "path/ocfl-root/#{OCFL_OBJECT_REL_PATH}"
+  end
+
+  # Build a stub OCFL storage location that reports type 'ocfl' and can relativize paths.
+  def build_ocfl_location(path: path_src_dir, md_path: md_src_dir)
+    loc = instance_double('Longleaf::OcflStorageLocation',
+      name: 'ocfl_src',
+      type: ST::OCFL_STORAGE_TYPE,
+      path: path
+    )
+    allow(loc).to receive(:relativize) { |fp| fp.sub(/\A#{Regexp.escape(path.chomp('/'))}\//, '') }
+    loc
+  end
+
+  def make_file_record(object_path, storage_loc)
+    build(:file_record,
+      file_path: object_path,
+      storage_location: storage_loc,
+      physical_path: object_path)
+  end
+
+  def make_service_def(destinations, collision: nil)
+    properties = {}
+    properties[SF::REPLICATE_TO] = destinations
+    properties[SF::COLLISION_PROPERTY] = collision unless collision.nil?
+    build(:service_definition, properties: properties)
+  end
+
+  let(:loc_manager) { instance_double('Longleaf::StorageLocationManager',
+        locations: { 'dest_loc' => dest }) }
+  let(:app_manager) { instance_double('Longleaf::ApplicationConfigManager',
+        location_manager: loc_manager) }
+
+  # ── initialize ────────────────────────────────────────────────────────────
+
+  describe '.initialize' do
+    let(:dest) { build(:s3_storage_location, metadata_path: md_dest_dir) }
+
+
+    context 'with valid configuration' do
+      let(:service_def) { make_service_def(['dest_loc']) }
+
+      it 'constructs without error' do
+        expect { OcflS3Service.new(service_def, app_manager) }.not_to raise_error
+      end
+
+      it 'uses the default collision policy' do
+        service = OcflS3Service.new(service_def, app_manager)
+        expect(service.collision_policy).to eq(SF::DEFAULT_COLLISION_POLICY)
+      end
+    end
+
+    context 'with an explicit valid collision policy' do
+      let(:service_def) { make_service_def(['dest_loc'], collision: 'replace') }
+
+      it 'accepts the policy' do
+        service = OcflS3Service.new(service_def, app_manager)
+        expect(service.collision_policy).to eq('replace')
+      end
+    end
+
+    context 'with an invalid collision policy' do
+      let(:service_def) { make_service_def(['dest_loc'], collision: 'do_nothing') }
+
+      it 'raises ArgumentError' do
+        expect { OcflS3Service.new(service_def, app_manager) }
+          .to raise_error(ArgumentError, /invalid replica_collision_policy/)
+      end
+    end
+
+    context 'with no destinations' do
+      let(:service_def) { make_service_def([]) }
+
+      it 'raises ArgumentError' do
+        expect { OcflS3Service.new(service_def, app_manager) }
+          .to raise_error(ArgumentError, /one or more replication destinations/)
+      end
+    end
+
+    context 'with an unknown destination' do
+      let(:service_def) { make_service_def(['nowhere_loc']) }
+
+      it 'raises ArgumentError' do
+        expect { OcflS3Service.new(service_def, app_manager) }
+          .to raise_error(ArgumentError, /unknown storage location/)
+      end
+    end
+
+    context 'when the destination is a filesystem location rather than S3' do
+      let(:fs_dest) { build(:storage_location, path: path_src_dir, metadata_path: md_src_dir) }
+      let(:loc_manager) { instance_double('Longleaf::StorageLocationManager',
+          locations: { 'dest_loc' => fs_dest }) }
+      let(:service_def) { make_service_def(['dest_loc']) }
+
+      it 'raises ArgumentError' do
+        expect { OcflS3Service.new(service_def, app_manager) }
+          .to raise_error(ArgumentError, /not of type 's3'/)
+      end
+    end
+  end
+
+  # ── is_applicable? ────────────────────────────────────────────────────────
+
+  describe '.is_applicable?' do
+    let(:dest) { build(:s3_storage_location, metadata_path: md_dest_dir) }
+    let(:service) { OcflS3Service.new(make_service_def(['dest_loc']), app_manager) }
+
+    it 'returns true for PRESERVE' do
+      expect(service.is_applicable?(PRESERVE_EVENT)).to be true
+    end
+
+    it 'returns false for REGISTER' do
+      expect(service.is_applicable?(Longleaf::EventNames::REGISTER)).to be false
+    end
+
+    it 'returns false for unknown events' do
+      expect(service.is_applicable?('something_else')).to be false
+    end
+  end
+
+  # ── perform ───────────────────────────────────────────────────────────────
+
+  describe '.perform' do
+    let(:dest)         { build(:s3_storage_location, metadata_path: md_dest_dir) }
+    let(:service)      { OcflS3Service.new(make_service_def(['dest_loc']), app_manager) }
+    let(:source_loc)   { build_ocfl_location }
+    let(:file_rec)     { make_file_record(ocfl_object_path, source_loc) }
+
+    before { setup_ocfl_fixture }
+
+    def retrieve_uploaded_keys
+        dest.s3_client.api_requests
+          .select { |r| r[:operation_name] == :put_object }
+          .map { |r| r[:params][:key] }
+    end
+
+    context 'when the source is not an OCFL storage location' do
+      let(:fs_loc) { build(:storage_location, path: path_src_dir, metadata_path: md_src_dir) }
+
+      it 'raises PreservationServiceError' do
+        fr = build(:file_record, file_path: ocfl_object_path,
+          storage_location: fs_loc, physical_path: ocfl_object_path)
+        expect { service.perform(fr, PRESERVE_EVENT) }
+          .to raise_error(PreservationServiceError, /only supports replication from OCFL/)
+      end
+    end
+
+    context 'when the OCFL object directory does not exist' do
+      it 'raises PreservationServiceError' do
+        fr = make_file_record('/does/not/exist', source_loc)
+        expect { service.perform(fr, PRESERVE_EVENT) }
+          .to raise_error(PreservationServiceError, /does not exist/)
+      end
+    end
+
+    context 'when the destination bucket is unavailable' do
+      before { dest.s3_client.stub_responses(:head_bucket, 'NotFound') }
+
+      it 'raises StorageLocationUnavailableError' do
+        expect { service.perform(file_rec, PRESERVE_EVENT) }
+          .to raise_error(Longleaf::StorageLocationUnavailableError)
+      end
+    end
+
+    context 'when the S3 upload fails' do
+      before { dest.s3_client.stub_responses(:put_object, 'InternalError') }
+
+      it 'raises PreservationServiceError' do
+        expect { service.perform(file_rec, PRESERVE_EVENT) }
+          .to raise_error(PreservationServiceError, /Failed to transfer/)
+      end
+    end
+
+    context 'full upload of a fresh OCFL object (no prior S3 objects)' do
+      before do
+        # Ensure head_object always returns 404 so every file is uploaded
+        dest.s3_client.stub_responses(:head_object, 'NoSuchKey')
+      end
+      it 'uploads every file in the object directory' do
+        service.perform(file_rec, PRESERVE_EVENT)
+
+        uploaded_keys = retrieve_uploaded_keys
+
+        local_files = []
+        Find.find(ocfl_object_path) do |p|
+          next if File.directory?(p)
+          rel = p.sub("#{ocfl_object_path}/", '')
+          local_files << "#{s3_object_prefix}/#{rel}"
+        end
+
+        expect(uploaded_keys).to match_array(local_files)
+      end
+
+      it 'issues a head_object check for every file' do
+        service.perform(file_rec, PRESERVE_EVENT)
+
+        head_keys = dest.s3_client.api_requests
+          .select { |r| r[:operation_name] == :head_object }
+          .map { |r| r[:params][:key] }
+
+        local_files = []
+        Find.find(ocfl_object_path) do |p|
+          next if File.directory?(p)
+          rel = p.sub("#{ocfl_object_path}/", '')
+          local_files << "#{s3_object_prefix}/#{rel}"
+        end
+
+        expect(head_keys).to match_array(local_files)
+      end
+    end
+
+    context 'skip behaviour based on file type' do
+      # Pre-populate S3 with stubbed head_object responses for selected keys.
+      def stub_s3_object_exists(s3_key, local_path)
+        md5 = Digest::MD5.file(local_path).hexdigest
+        dest.s3_client.stub_responses(:head_object,
+          ->(context) {
+            context.params[:key] == s3_key ?
+              { content_length: File.size(local_path), etag: "\"#{md5}\"" } :
+              'NoSuchKey'
+          }
+        )
+      end
+
+      context 'vN/ file that already exists unchanged in S3' do
+        let(:version_inv_local) { File.join(ocfl_object_path, 'v1', 'inventory.json') }
+        let(:s3_key)  { "#{s3_object_prefix}/v1/inventory.json" }
+
+        before do
+          # Respond with some non-nil content_length; ETag is irrelevant for vN/ files
+          dest.s3_client.stub_responses(:head_object,
+            ->(context) {
+              context.params[:key] == s3_key ?
+                { content_length: File.size(version_inv_local), etag: '"irrelevant"' } :
+                'NoSuchKey'
+            }
+          )
+        end
+
+        it 'skips the upload without computing an MD5' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          uploaded_keys = retrieve_uploaded_keys
+
+          expect(uploaded_keys).not_to include(s3_key)
+        end
+      end
+
+      context 'root inventory.json that already exists with matching ETag' do
+        let(:root_inv_local) { File.join(ocfl_object_path, 'inventory.json') }
+        let(:s3_key)         { "#{s3_object_prefix}/inventory.json" }
+
+        before { stub_s3_object_exists(s3_key, root_inv_local) }
+
+        it 'skips the upload' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          uploaded_keys = retrieve_uploaded_keys
+
+          expect(uploaded_keys).not_to include(s3_key)
+        end
+      end
+
+      context 'root inventory.json.sha512 whose content changed but size is identical' do
+        let(:sidecar_local) { File.join(ocfl_object_path, 'inventory.json.sha512') }
+        let(:s3_key)        { "#{s3_object_prefix}/inventory.json.sha512" }
+
+        before do
+          original_md5 = Digest::MD5.file(sidecar_local).hexdigest
+          stale_md5 = original_md5.tr('0-9a-f', 'a-f0-9') # shift every digit by 10 to ensure the "old" md5 is different
+          dest.s3_client.stub_responses(:head_object,
+            ->(context) {
+              context.params[:key] == s3_key ?
+                { content_length: File.size(sidecar_local), etag: "\"#{stale_md5}\"" } :
+                'NoSuchKey'
+            }
+          )
+        end
+
+        it 're-uploads the sidecar because the ETag differs' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          uploaded_keys = retrieve_uploaded_keys
+
+          expect(uploaded_keys).to include(s3_key)
+        end
+      end
+
+      context 'root inventory.json with a multipart ETag and unchanged size' do
+        let(:root_inv_local) { File.join(ocfl_object_path, 'inventory.json') }
+        let(:s3_key)         { "#{s3_object_prefix}/inventory.json" }
+
+        before do
+          dest.s3_client.stub_responses(:head_object,
+            ->(context) {
+              context.params[:key] == s3_key ?
+                # Multipart ETag because it contains a - character
+                { content_length: File.size(root_inv_local), etag: '"abc123-3"' } :
+                'NoSuchKey'
+            }
+          )
+        end
+
+        it 'skips the upload using size as a fallback' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          uploaded_keys = retrieve_uploaded_keys
+
+          expect(uploaded_keys).not_to include(s3_key)
+        end
+      end
+
+      context 'root inventory.json with a multipart ETag and changed size' do
+        let(:root_inv_local) { File.join(ocfl_object_path, 'inventory.json') }
+        let(:s3_key)         { "#{s3_object_prefix}/inventory.json" }
+
+        before do
+          dest.s3_client.stub_responses(:head_object,
+            ->(context) {
+              context.params[:key] == s3_key ?
+                { content_length: File.size(root_inv_local) - 8, etag: '"abc123-3"' } :
+                'NoSuchKey'
+            }
+          )
+        end
+
+        it 're-uploads the inventory because the size differs' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          uploaded_keys = retrieve_uploaded_keys
+
+          expect(uploaded_keys).to include(s3_key)
+        end
+      end
+    end
+
+    context 'mutable head cleanup' do
+      let(:mutable_head_dir) do
+        dir = File.join(ocfl_object_path, 'extensions', '0005-mutable-head')
+        FileUtils.mkdir_p(File.join(dir, 'head', 'content', 'r1'))
+        FileUtils.mkdir_p(File.join(dir, 'revisions'))
+        dir
+      end
+
+      before do
+        # Ensure the mutable head directory exists
+        mutable_head_dir
+      end
+
+      context 'when a stale mutable head object exists in S3 but not locally' do
+        let(:stale_key) { "#{s3_object_prefix}/extensions/0005-mutable-head/head/content/r1/old_file.bin" }
+        let(:mutable_head_prefix) { "#{s3_object_prefix}/extensions/0005-mutable-head/" }
+
+        before do
+          # Stub list_objects_v2 to return the stale mutable head key under the prefix
+          dest.s3_client.stub_responses(:list_objects_v2,
+            ->(context) {
+              if context.params[:prefix] == mutable_head_prefix
+                {
+                  contents: [{ key: stale_key, size: 100, etag: '"abc"' }],
+                  is_truncated: false
+                }
+              else
+                { contents: [], is_truncated: false }
+              end
+            }
+          )
+        end
+
+        it 'deletes the stale S3 object' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          delete_requests = dest.s3_client.api_requests
+            .select { |r| r[:operation_name] == :delete_objects }
+
+          deleted_keys = delete_requests.flat_map { |r| r[:params][:delete][:objects].map { |o| o[:key] } }
+          expect(deleted_keys).to include(stale_key)
+          expect(deleted_keys.length()).to eq 1
+        end
+      end
+
+      context 'when a mutable head file exists both locally and in S3' do
+        let(:local_head_file) do
+          path = File.join(mutable_head_dir, 'head', 'content', 'r1', 'current_file.bin')
+          File.write(path, 'active content')
+          path
+        end
+        let(:head_file_rel)  { "extensions/0005-mutable-head/head/content/r1/current_file.bin" }
+        let(:head_file_key)  { "#{s3_object_prefix}/#{head_file_rel}" }
+        let(:mutable_head_prefix) { "#{s3_object_prefix}/extensions/0005-mutable-head/" }
+
+        before do
+          local_head_file # create the file
+          dest.s3_client.stub_responses(:list_objects_v2,
+            ->(context) {
+              if context.params[:prefix] == mutable_head_prefix
+                {
+                  contents: [{ key: head_file_key, size: File.size(local_head_file), etag: '"xyz"' }],
+                  is_truncated: false
+                }
+              else
+                { contents: [], is_truncated: false }
+              end
+            }
+          )
+        end
+
+        it 'does not delete the object that still exists locally' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          delete_requests = dest.s3_client.api_requests
+            .select { |r| r[:operation_name] == :delete_objects }
+          expect(delete_requests).to be_empty
+        end
+      end
+
+      context 'when a stale object exists outside the mutable head subtree' do
+        let(:stale_version_key) { "#{s3_object_prefix}/v99/inventory.json" }
+        # Populated multiple head file so that it doesn't get detected as deleted
+        let!(:local_mutable_file) do
+          path = File.join(ocfl_object_path, 'extensions', '0005-mutable-head', 'head', 'inventory.json')
+          FileUtils.mkdir_p(File.dirname(path))
+          File.write(path, '{}')
+          path
+        end
+        let(:present_mutable_key) { "#{s3_object_prefix}/extensions/0005-mutable-head/head/inventory.json" }
+        let(:mutable_head_prefix) { "#{s3_object_prefix}/extensions/0005-mutable-head/" }
+
+        before do
+          dest.s3_client.stub_responses(:list_objects_v2,
+            ->(context) {
+              if context.params[:prefix] == mutable_head_prefix
+                {
+                  contents: [{ key: present_mutable_key, size: 2, etag: '"aaa"' }],
+                  is_truncated: false
+                }
+              else
+                { contents: [], is_truncated: false }
+              end
+            }
+          )
+        end
+
+        it 'does not delete objects outside the mutable head prefix' do
+          service.perform(file_rec, PRESERVE_EVENT)
+
+          delete_requests = dest.s3_client.api_requests
+            .select { |r| r[:operation_name] == :delete_objects }
+          expect(delete_requests).to be_empty
+        end
+      end
+    end
+
+    context 'with multiple destinations' do
+      let(:md_dest_dir2) { Dir.mktmpdir('dest2_metadata') }
+      let(:dest2)        { build(:s3_storage_location,
+          path: 'https://anotherbucket.s3-amazonaws.com/',
+          metadata_path: md_dest_dir2) }
+      let(:loc_manager)  { instance_double('Longleaf::StorageLocationManager',
+          locations: { 'dest_loc' => dest, 'dest_loc2' => dest2 }) }
+      let(:service)      { OcflS3Service.new(make_service_def(['dest_loc', 'dest_loc2']), app_manager) }
+
+      after { FileUtils.rm_rf(md_dest_dir2) }
+
+      it 'uploads to both destinations' do
+        service.perform(file_rec, PRESERVE_EVENT)
+
+        [dest, dest2].each do |d|
+          uploaded = d.s3_client.api_requests
+            .select { |r| r[:operation_name] == :put_object }
+          expect(uploaded).not_to be_empty
+        end
+      end
+    end
+  end
+
+  describe '.versioned_object_file?' do
+    let(:dest) { build(:s3_storage_location, metadata_path: md_dest_dir) }
+    let(:service) { OcflS3Service.new(make_service_def(['dest_loc']), app_manager) }
+
+    { 'v1/inventory.json'                                          => true,
+      'v2/content/r1/foo.txt'                                      => true,
+      'v10/inventory.json.sha512'                                  => true,
+      'inventory.json'                                             => false,
+      'inventory.json.sha512'                                      => false,
+      '0=ocfl_object_1.1'                                          => false,
+      'extensions/0005-mutable-head/head/inventory.json'           => false,
+      'extensions/0005-mutable-head/head/content/r1/file.txt'      => false,
+      'extensions/0005-mutable-head/revisions/r1'                  => false,
+      'extensions/0005-mutable-head/root-inventory.json.sha512'    => false
+    }.each do |path, expected|
+      it "returns #{expected} for '#{path}'" do
+        expect(service.send(:versioned_object_file?, path)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
+++ b/spec/longleaf/preservation_services/ocfl_s3_replication_service_spec.rb
@@ -13,8 +13,8 @@ require 'tmpdir'
 describe Longleaf::OcflS3ReplicationService do
   include Longleaf::FileHelpers
 
-  SF   ||= Longleaf::ServiceFields
-  ST   ||= Longleaf::StorageTypes
+  SF ||= Longleaf::ServiceFields
+  ST ||= Longleaf::StorageTypes
   OcflS3Service ||= Longleaf::OcflS3ReplicationService
   PRESERVE_EVENT ||= Longleaf::EventNames::PRESERVE
   PreservationServiceError ||= Longleaf::PreservationServiceError


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5526

This pull request introduces significant improvements to OCFL (Oxford Common File Layout) support in Longleaf, especially around object type handling, S3 replication, and configuration flexibility. The most notable change is the addition of a new `OcflS3ReplicationService` for replicating OCFL objects to S3, along with enhanced logic for object type detection and propagation, and support for the OCFL mutable head extension. Several related code simplifications and bug fixes are also included.

**OCFL Object Handling and Replication Improvements:**

* Added a new `OcflS3ReplicationService` for replicating OCFL objects to S3 destinations, with support for efficient delta uploads, immutable version detection, and cleanup of stale mutable head files.
* Enhanced `OcflStorageLocation` to provide a `default_object_type`, report support for the OCFL mutable head extension, and override metadata path handling for OCFL object directories. [[1]](diffhunk://#diff-d421b39f2a22cac119741324159518417c74cf476867bd0b8b43b65fa25ce7f8R29-R37) [[2]](diffhunk://#diff-d421b39f2a22cac119741324159518417c74cf476867bd0b8b43b65fa25ce7f8R48-R80)
* Improved file registration logic to automatically assign the correct object type based on the storage location, removing the need for the `--ocfl` CLI option and explicit object type passing. [[1]](diffhunk://#diff-fdd6e800ddee8012298463d17ad133f223caa14fc6e1f2392a3107b084e61e66L145-L149) [[2]](diffhunk://#diff-a3934e2c1cebaadaf0d9f3e4848d930c68ad4292b0a96e9caa0ede41dcaf0588L38-R37) [[3]](diffhunk://#diff-bb2619a39d0338d3ced68a50567a7844b64d3331c8bad8d38c7443a23ff8cb1cL20-R20)
* Updated selection logic to detect and prevent mixing OCFL and non-OCFL storage locations in a single operation, increasing reliability and user feedback.

**Preservation and Replication Service Fixes:**

* Fixed last-modified timestamp comparison for OCFL object checks to use ISO8601 UTC format, which always failed due to a precision mismatch. [[1]](diffhunk://#diff-d1795be0c11c29d9beb1f140a138bdbced9b220fcd24f7e8d59c227484fa0177R37) [[2]](diffhunk://#diff-d1795be0c11c29d9beb1f140a138bdbced9b220fcd24f7e8d59c227484fa0177L46-R48)
* Added missing -R flag to OCFL rsync replication, otherwise it would fail because the target was a directory.
* Corrected destination location assignment in `S3ReplicationService` initialization.

**Dependency and Code Cleanup:**

* Removed unused or redundant requires, fixed a persistent deprecation warning related to the upload_file method, and updated dependencies where necessary for clarity and maintainability. [[1]](diffhunk://#diff-a3934e2c1cebaadaf0d9f3e4848d930c68ad4292b0a96e9caa0ede41dcaf0588L7) [[2]](diffhunk://#diff-d421b39f2a22cac119741324159518417c74cf476867bd0b8b43b65fa25ce7f8R7) [[3]](diffhunk://#diff-e48383b42d0af2bba9cb50ee64969853093c8d88fccebcf6e6c424fc12597674L6)