### PR TITLE
Fix undefined constant and variable typos in application_config_deser…

### DIFF
--- a/lib/longleaf/services/application_config_deserializer.rb
+++ b/lib/longleaf/services/application_config_deserializer.rb
@@ -66,7 +66,7 @@ module Longleaf
           next
         end
         if md_config.is_a?(String)
-          md_config = { AF::LOCATION => m_config }
+          md_config = { AF::LOCATION_PATH => md_config }
         end
         md_config[AF::LOCATION_PATH] = make_file_paths_absolute(base_pathname, md_config)
       end


### PR DESCRIPTION
Application Config Deserializer

Line 69 of make_paths_absolute had two typos triggered when the 'metadata' config key is provided as a plain string path:
- AF::LOCATION (undefined constant) corrected to AF::LOCATION_PATH
- m_config (undefined variable) corrected to md_config