### PR TITLE
Fix metadata config not written back to properties in application_con…

### DIFF
--- a/lib/longleaf/services/application_config_deserializer.rb
+++ b/lib/longleaf/services/application_config_deserializer.rb
@@ -67,6 +67,7 @@ module Longleaf
         end
         if md_config.is_a?(String)
           md_config = { AF::LOCATION => m_config }
+          properties[AF::METADATA_CONFIG] = md_config
         end
         md_config[AF::LOCATION_PATH] = make_file_paths_absolute(base_pathname, md_config)
       end


### PR DESCRIPTION

When the 'metadata' config key is a plain string, make_paths_absolute rebuilds it as a hash but never assigns it back into properties, so the validator still sees the original string and raises 'path must not be empty'.

[Please note: this pull request and the other related one are both what Claude Code noticed and tried on its own to fix]